### PR TITLE
__constructor implementation

### DIFF
--- a/stellar/contracts/wormhole-contract/src/governance/action.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/action.rs
@@ -4,7 +4,7 @@
 //! providing a standard flow: verify VAA → check replay → parse payload →
 //! validate → consume → execute.
 
-use crate::{initialize, storage::StorageKey, utils::keccak256_hash, vaa::verify_vaa};
+use crate::{storage::StorageKey, utils::keccak256_hash, vaa::verify_vaa};
 use core::convert::TryFrom;
 use soroban_sdk::{Bytes, BytesN, Env};
 use wormhole_soroban_client::{
@@ -32,15 +32,12 @@ pub trait GovernanceAction {
 
     /// Standard governance submission flow with replay protection.
     ///
-    /// 1. Verify contract is initialized
-    /// 2. Parse and verify VAA (signatures + governance source)
-    /// 3. Check VAA not already consumed
-    /// 4. Parse and validate payload
-    /// 5. **Consume VAA (before execution!)**
-    /// 6. Execute the action
+    /// 1. Parse and verify VAA (signatures + governance source)
+    /// 2. Check VAA not already consumed
+    /// 3. Parse and validate payload
+    /// 4. **Consume VAA (before execution!)**
+    /// 5. Execute the action
     fn submit(env: &Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
-        initialize::require_initialized(env)?;
-
         let (vaa, vaa_hash) = verify_and_hash_governance_vaa(env, &vaa_bytes)?;
         require_vaa_not_consumed(env, &vaa_hash)?;
 

--- a/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
@@ -7,7 +7,6 @@
 
 use crate::{
     governance::action::{GovernanceAction, parse_governance_header, validate_governance_header},
-    initialize,
     storage::StorageKey,
 };
 use core::convert::TryFrom;
@@ -133,19 +132,19 @@ pub fn get_guardian_set_expiry(env: &Env, index: u32) -> Option<u64> {
 
 /// Stores a new guardian set at the given index.
 ///
-/// Index 0 is only valid during initialization. Subsequent indices must be
-/// strictly sequential (current + 1) and cannot overwrite existing sets.
+/// Index 0 is only valid during constructor (guardian set won't exist yet).
+/// Subsequent indices must be strictly sequential (current + 1).
+/// Cannot overwrite existing guardian sets.
 pub fn store(env: &Env, index: u32, set: GuardianSetInfo) -> Result<(), WormholeError> {
     let current_index = get_current_guardian_set_index(env);
 
-    if index == 0 {
-        if initialize::is_initialized(env) {
-            return Err(WormholeError::GuardianSetAlreadyExists);
-        }
-    } else if index != current_index.saturating_add(1) {
+    // Index 0 is only valid during constructor (guardian set won't exist yet)
+    // All other indices must be current + 1 for proper sequencing
+    if index != 0 && index != current_index.saturating_add(1) {
         return Err(WormholeError::InvalidGuardianSetSequence);
     }
 
+    // Cannot overwrite existing guardian sets (including index 0 after constructor)
     if get_guardian_set(env, index).is_ok() {
         return Err(WormholeError::GuardianSetAlreadyExists);
     }
@@ -174,15 +173,6 @@ fn set_expiry(env: &Env, index: u32, expiry: u64) {
         STORAGE_TTL_THRESHOLD,
         STORAGE_TTL_EXTENSION,
     );
-}
-
-/// Marks a guardian set to expire in 24 hours from now.
-fn expire_guardian_set(env: &Env, index: u32) {
-    let expiry = env
-        .ledger()
-        .timestamp()
-        .saturating_add(u64::from(GUARDIAN_SET_EXPIRATION_TIME));
-    set_expiry(env, index, expiry);
 }
 
 /// Governance action handler for guardian set upgrades.

--- a/stellar/contracts/wormhole-contract/src/governance/mod.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/mod.rs
@@ -25,7 +25,6 @@ pub use guardian_set::GuardianSetUpgradeAction;
 pub use set_message_fee::{SetMessageFeeAction, get_message_fee};
 pub use transfer_fees::{TransferFeesAction, get_last_fee_transfer};
 
-use crate::initialize;
 use soroban_sdk::{Bytes, Env};
 use wormhole_soroban_client::WormholeError;
 
@@ -33,7 +32,6 @@ use wormhole_soroban_client::WormholeError;
 ///
 /// Returns `Ok(())` if not consumed, `Err(GovernanceVAAAlreadyConsumed)` if already used.
 pub fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
-    initialize::require_initialized(&env)?;
     if action::is_governance_vaa_consumed_from_bytes(&env, &vaa_bytes)? {
         Err(WormholeError::GovernanceVAAAlreadyConsumed)
     } else {

--- a/stellar/contracts/wormhole-contract/src/initialize.rs
+++ b/stellar/contracts/wormhole-contract/src/initialize.rs
@@ -1,7 +1,10 @@
 //! Contract initialization logic.
 //!
-//! Handles one-time setup of the Wormhole Core contract, including guardian set
-//! creation, admin configuration, and governance emitter storage.
+//! Handles setup of the Wormhole Core contract via the `__constructor` function,
+//! including guardian set creation, admin configuration, and governance emitter storage.
+//!
+//! This module is only called by the constructor, which is executed atomically
+//! during deployment (Protocol 22+). The runtime guarantees single execution.
 
 use crate::{
     governance::guardian_set::{set_current_index, store},
@@ -25,50 +28,25 @@ struct InitializeEvent {
     governance_emitter: BytesN<32>,
 }
 
-/// Checks whether the contract has been initialized.
-pub fn is_initialized(env: &Env) -> bool {
-    env.storage()
-        .persistent()
-        .get(&StorageKey::Initialized)
-        .unwrap_or(false)
-}
-
-/// Guard that returns `NotInitialized` if the contract hasn't been set up.
-pub fn require_initialized(env: &Env) -> Result<(), WormholeError> {
-    if !is_initialized(env) {
-        return Err(WormholeError::NotInitialized);
-    }
-    Ok(())
-}
-
-/// Marks the contract as initialized (internal use only).
-fn set_initialized(env: &Env) {
-    env.storage()
-        .persistent()
-        .set(&StorageKey::Initialized, &true);
-}
-
-/// Performs one-time contract initialization.
+/// Internal initialization logic called by `__constructor`.
 ///
 /// Sets up the initial guardian set (index 0), configures the contract as its own
 /// admin for upgrades, and stores the governance emitter address.
 ///
-/// # Errors
+/// # Arguments
+/// * `initial_guardians` - Ethereum addresses (20 bytes) of initial guardians
+/// * `governance_emitter` - 32-byte address authorized to emit governance VAAs
 ///
-/// - `AlreadyInitialized` if called more than once
-/// - `EmptyGuardianSet` if no guardians provided
-pub fn initialize(
+/// # Panics
+/// Panics with `EmptyGuardianSet` if no guardians are provided.
+pub(crate) fn initialize_internal(
     env: &Env,
     initial_guardians: Vec<BytesN<20>>,
     governance_emitter: BytesN<32>,
-) -> Result<(), WormholeError> {
-    if is_initialized(env) {
-        return Err(WormholeError::AlreadyInitialized);
-    }
-
-    // Validate initial guardians
+) {
+    // Validate initial guardians - panic on failure (constructor semantics)
     if initial_guardians.is_empty() {
-        return Err(WormholeError::EmptyGuardianSet);
+        env.panic_with_error(WormholeError::EmptyGuardianSet);
     }
 
     // Set contract as its own admin for upgrades
@@ -95,11 +73,12 @@ pub fn initialize(
         creation_time: env.ledger().timestamp(),
     };
 
-    store(env, 0, guardian_set)?;
+    // Panic on storage failure (constructor semantics)
+    if let Err(e) = store(env, 0, guardian_set) {
+        env.panic_with_error(e);
+    }
 
     set_current_index(env, 0);
-
-    set_initialized(env);
 
     // Emit initialization event
     InitializeEvent {
@@ -109,6 +88,4 @@ pub fn initialize(
         governance_emitter: governance_emitter.clone(),
     }
     .publish(env);
-
-    Ok(())
 }

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -16,7 +16,7 @@
 
 use soroban_sdk::{Address, Bytes, BytesN, Env, Vec, contract, contractimpl};
 use wormhole_soroban_client::{
-    ConsistencyLevel, GuardianSetInfo, WormholeCoreInterface, WormholeError, CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER
+    ConsistencyLevel, GuardianSetInfo, WormholeCoreInterface, WormholeError, CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID,
 };
 use crate::governance::{
     guardian_set::get_current_guardian_set_index, guardian_set::get_guardian_set, guardian_set::get_guardian_set_expiry,
@@ -37,20 +37,32 @@ mod vaa;
 #[contract]
 pub struct Wormhole;
 
+/// Constructor and non-trait methods.
 #[contractimpl]
-impl WormholeCoreInterface for Wormhole {
-    fn initialize(
+impl Wormhole {
+    /// Constructor called atomically during contract deployment.
+    ///
+    /// Sets up the initial guardian set (index 0), configures the contract as its
+    /// own admin for governance upgrades, and stores the governance emitter address.
+    ///
+    /// # Arguments
+    /// * `initial_guardians` - Ethereum addresses (20 bytes) of initial guardians
+    /// * `governance_emitter` - 32-byte address authorized to emit governance VAAs
+    ///
+    /// # Panics
+    /// Panics with `EmptyGuardianSet` if no guardians are provided.
+    pub fn __constructor(
         env: Env,
         initial_guardians: Vec<BytesN<20>>,
         governance_emitter: BytesN<32>,
-    ) -> Result<(), WormholeError> {
-        initialize::initialize(&env, initial_guardians, governance_emitter)
+    ) {
+        initialize::initialize_internal(&env, initial_guardians, governance_emitter);
     }
+}
 
-    fn is_initialized(env: Env) -> bool {
-        initialize::is_initialized(&env)
-    }
-
+/// Implementation of the public Wormhole Core interface.
+#[contractimpl]
+impl WormholeCoreInterface for Wormhole {
     fn verify_vaa(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
         vaa::verify_vaa(&env, &vaa_bytes)?;
         Ok(())
@@ -138,12 +150,10 @@ impl WormholeCoreInterface for Wormhole {
     }
 
     fn get_governance_emitter(env: Env) -> BytesN<32> {
+        // Constructor guarantees this is always set
         env.storage()
             .persistent()
             .get(&storage::StorageKey::GovernanceEmitter)
-            .unwrap_or_else(|| {
-                // Fallback to default if not initialized
-                BytesN::from_array(&env, &GOVERNANCE_EMITTER)
-            })
+            .expect("governance emitter not set")
     }
 }

--- a/stellar/contracts/wormhole-contract/src/message.rs
+++ b/stellar/contracts/wormhole-contract/src/message.rs
@@ -10,7 +10,7 @@ use wormhole_soroban_client::{
 };
 
 use crate::{
-    governance, initialize,
+    governance,
     storage::StorageKey,
     utils::{address_to_bytes32, get_native_token_address, keccak256_hash},
 };
@@ -126,7 +126,6 @@ fn store_posted_message(env: &Env, emitter: &Address, sequence: u64, message_has
 ///
 /// # Errors
 ///
-/// - `NotInitialized` if the contract hasn't been initialized
 /// - `InsufficientFeePaid` if fee collection fails (requires prior approval)
 pub fn post_message_with_fee(
     env: &Env,
@@ -135,8 +134,6 @@ pub fn post_message_with_fee(
     payload: Bytes,
     consistency_level: ConsistencyLevel,
 ) -> Result<u64, WormholeError> {
-    initialize::require_initialized(env)?;
-
     let required_fee = governance::get_message_fee(env);
 
     if required_fee > 0 {

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -14,8 +14,6 @@ use soroban_sdk::{Address, BytesN, contracttype};
 pub enum StorageKey {
     /// Index of the currently active guardian set (starts at 0).
     CurrentGuardianSetIndex,
-    /// Boolean flag indicating contract initialization status.
-    Initialized,
     /// Contract's admin address (set to itself for self-upgrade via governance).
     Admin,
     /// 32-byte address authorized to emit governance VAAs.

--- a/stellar/contracts/wormhole-soroban-client/src/error.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/error.rs
@@ -1,8 +1,8 @@
 //! Error types for the Wormhole Core contract.
 //!
 //! All contract operations return `Result<T, WormholeError>`. Error codes are
-//! grouped by category (VAA, initialization, governance, storage, fees) with
-//! reserved numeric ranges for future expansion.
+//! grouped by category (VAA, governance, storage, fees) with reserved numeric
+//! ranges for future expansion.
 
 use soroban_sdk::contracterror;
 
@@ -10,7 +10,6 @@ use soroban_sdk::contracterror;
 ///
 /// Error codes are organized into ranges:
 /// - 1-19: VAA parsing and verification errors
-/// - 20-29: Contract initialization errors
 /// - 30-39: Governance action errors
 /// - 40-49: Storage and guardian set errors
 /// - 50-59: Fee-related errors
@@ -41,13 +40,6 @@ pub enum WormholeError {
     InvalidEmitterAddress = 9,
     /// Payload bytes are malformed or insufficient length.
     InvalidPayload = 10,
-
-    // ========== Initialization Errors (20-29) ==========
-
-    /// Contract has already been initialized.
-    AlreadyInitialized = 20,
-    /// Contract must be initialized before this operation.
-    NotInitialized = 21,
 
     // ========== Governance Errors (30-39) ==========
 

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -36,7 +36,7 @@ pub use constants::*;
 pub use error::WormholeError;
 pub use types::*;
 
-use soroban_sdk::{Address, Bytes, BytesN, Env, Vec};
+use soroban_sdk::{Address, Bytes, BytesN, Env};
 
 /// Complete public interface for the Wormhole Core contract.
 ///
@@ -49,33 +49,13 @@ use soroban_sdk::{Address, Bytes, BytesN, Env, Vec};
 /// - Governance actions require VAAs signed by a quorum (13/19) of guardians
 /// - VAAs are consumed after use to prevent replay attacks
 /// - The contract is its own admin—upgrades require guardian consensus
+///
+/// # Initialization
+///
+/// The contract is initialized via `__constructor` at deployment time.
+/// Constructor arguments (initial guardians and governance emitter) are passed
+/// during the `stellar contract deploy` command after `--`.
 pub trait WormholeCoreInterface {
-    // ========== Initialization ==========
-
-    /// Initialize the contract with the initial guardian set and governance emitter.
-    /// Can only be called once.
-    ///
-    /// # Arguments
-    /// * `initial_guardians` - Ethereum addresses (20 bytes) of initial guardians
-    /// * `governance_emitter` - The governance emitter address (32 bytes) that can issue governance VAAs.
-    ///   For mainnet, this should be 0x0000000000000000000000000000000000000000000000000000000000000004
-    ///   For testnet, you may use a different address you control for testing.
-    ///
-    /// # Errors
-    /// * `Error::AlreadyInitialized` - Contract already initialized
-    /// * `Error::EmptyGuardianSet` - No guardians provided
-    fn initialize(
-        env: Env,
-        initial_guardians: Vec<BytesN<20>>,
-        governance_emitter: BytesN<32>,
-    ) -> Result<(), WormholeError>;
-
-    /// Check if the contract has been initialized.
-    ///
-    /// # Returns
-    /// `true` if initialized, `false` otherwise
-    fn is_initialized(env: Env) -> bool;
-
     // ========== VAA Verification ==========
 
     /// Verify a complete VAA (Verifiable Action Approval).
@@ -175,8 +155,7 @@ pub trait WormholeCoreInterface {
     /// Sequence number assigned to the message
     ///
     /// # Errors
-    /// * `Error::NotInitialized` - Contract not initialized
-    /// * `Error::InsufficientFeePaid` - Fee not paid
+    /// * `Error::InsufficientFeePaid` - Fee not paid (requires prior token approval)
     fn post_message(
         env: Env,
         emitter: Address,


### PR DESCRIPTION
Files Modified:
- `contracts/wormhole-soroban-client/src/lib.rs` - Removed initialize() and is_initialized() from the WormholeCoreInterface trait
- `contracts/wormhole-soroban-client/src/error.rs` - Removed AlreadyInitialized and NotInitialized error variants
- `contracts/wormhole-contract/src/lib.rs` - Added __constructor in a separate impl Wormhole block, removed initialization methods from trait impl
- `contracts/wormhole-contract/src/initialize.rs` - Refactored to initialize_internal() with env.panic_with_error() semantics
- `contracts/wormhole-contract/src/storage.rs` - Removed Initialized storage key variant
- `contracts/wormhole-contract/src/governance/guardian_set.rs` - Removed is_initialized check, simplified store logic, removed dead code
- `contracts/wormhole-contract/src/governance/action.rs` - Removed require_initialized() call from submit()
- `contracts/wormhole-contract/src/governance/mod.rs` - Removed require_initialized() call
- `contracts/wormhole-contract/src/message.rs` - Removed require_initialized() call
- `README.md` - Updated deployment instructions to show constructor pattern

Key Changes:
- Constructor runs atomically during stellar contract deploy with args after --
- No separate initialize() call needed
- Runtime guarantees single execution (no re-initialization possible)
- Smaller contract size (no initialization guards)