### PR TITLE
Wormhole Core Contract Fixes

### DIFF
--- a/stellar/ARCHITECTURE.md
+++ b/stellar/ARCHITECTURE.md
@@ -196,7 +196,6 @@ All governance actions follow the same pattern:
 | `GOVERNANCE_CHAIN_ID` | 1 | Solana (governance source) |
 | `GOVERNANCE_EMITTER` | `0x...04` | Authorized governance address |
 | `GUARDIAN_SET_EXPIRATION_TIME` | 86,400s | 24 hours grace period |
-| `MINIMUM_CONTRACT_BALANCE` | 10^7 stroops | 1 XLM minimum |
 | `STORAGE_TTL_THRESHOLD` | 100,000 | ~5.8 days |
 | `STORAGE_TTL_EXTENSION` | 1,000,000 | ~58 days |
 
@@ -212,11 +211,6 @@ All governance actions follow the same pattern:
 - Sets can only upgrade sequentially (n → n+1)
 - Old sets expire after 24 hours (grace period for in-flight VAAs)
 - Cannot overwrite existing sets
-
-### Balance Protection
-
-- Contract must maintain ≥1 XLM to prevent Stellar account deallocation
-- Fee transfers validate remaining balance
 
 ## Error Handling
 

--- a/stellar/contracts/wormhole-contract/src/governance/action.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/action.rs
@@ -4,7 +4,7 @@
 //! providing a standard flow: verify VAA → check replay → parse payload →
 //! validate → consume → execute.
 
-use crate::{storage::StorageKey, utils::keccak256_hash, vaa::verify_vaa};
+use crate::{storage::StorageKey, utils::keccak256_hash, vaa::verify_vaa_signatures};
 use core::convert::TryFrom;
 use soroban_sdk::{Bytes, BytesN, Env};
 use wormhole_soroban_client::{
@@ -72,7 +72,7 @@ fn verify_and_hash_governance_vaa(
 ) -> Result<(VAA, BytesN<32>), WormholeError> {
     let vaa = VAA::try_from((env, vaa_bytes))?;
     verify_governance_vaa(&vaa)?;
-    verify_vaa(env, vaa_bytes)?;
+    verify_vaa_signatures(&vaa, env)?;
 
     let body_bytes = vaa.serialize_body(env);
     let vaa_hash = keccak256_hash(env, &body_bytes);

--- a/stellar/contracts/wormhole-contract/src/governance/action.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/action.rs
@@ -176,7 +176,7 @@ mod tests {
 
     fn deploy_with_guardian(env: &Env, guardian_eth: BytesN<20>) -> soroban_sdk::Address {
         let initial_guardians = vec![env, guardian_eth];
-        let governance_emitter = BytesN::<32>::from_array(env, &[1u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
         env.register(Wormhole, (initial_guardians, governance_emitter))
     }
 
@@ -382,7 +382,7 @@ mod tests {
             Wormhole,
             (
                 vec![&env, BytesN::<20>::from_array(&env, &[0u8; 20])],
-                BytesN::<32>::from_array(&env, &[1u8; 32]),
+                BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER),
             ),
         );
         let body = Bytes::from_slice(&env, &[1u8; 51]);

--- a/stellar/contracts/wormhole-contract/src/governance/action.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/action.rs
@@ -8,8 +8,8 @@ use crate::{storage::StorageKey, utils::keccak256_hash, vaa::verify_vaa_signatur
 use core::convert::TryFrom;
 use soroban_sdk::{Bytes, BytesN, Env};
 use wormhole_soroban_client::{
-    BytesReader, CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, MODULE_CORE,
-    STORAGE_TTL_EXTENSION, STORAGE_TTL_THRESHOLD, VAA, WormholeError,
+    BytesReader, CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, MODULE_CORE, VAA,
+    WormholeError,
 };
 
 /// Trait for implementing Wormhole governance actions.
@@ -96,16 +96,14 @@ fn require_vaa_not_consumed(env: &Env, hash: &BytesN<32>) -> Result<(), Wormhole
 }
 
 /// Marks a VAA as consumed to prevent replay attacks.
+///
+/// Uses persistent storage, which is archived (not deleted) on TTL expiry.
+/// An attacker replaying a VAA whose entry was archived must first restore
+/// it via `RestoreFootprint`, at which point the consumed flag blocks replay.
 fn consume_vaa(env: &Env, hash: &BytesN<32>) {
     env.storage()
         .persistent()
         .set(&StorageKey::ConsumedGovernanceVAA(hash.clone()), &true);
-
-    env.storage().persistent().extend_ttl(
-        &StorageKey::ConsumedGovernanceVAA(hash.clone()),
-        STORAGE_TTL_THRESHOLD,
-        STORAGE_TTL_EXTENSION,
-    );
 }
 
 /// Checks if a governance VAA has been consumed without full verification.

--- a/stellar/contracts/wormhole-contract/src/governance/contract_upgrade.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/contract_upgrade.rs
@@ -52,6 +52,10 @@ impl<'a> TryFrom<(&'a Env, &'a Bytes)> for ContractUpgradePayload {
         let (module, action, chain) = parse_governance_header(env, &mut reader)?;
         let new_contract_hash = reader.read_bytes_n::<32>()?;
 
+        if reader.remaining() != 0 {
+            return Err(WormholeError::InvalidPayload);
+        }
+
         Ok(ContractUpgradePayload {
             module,
             action,

--- a/stellar/contracts/wormhole-contract/src/governance/contract_upgrade.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/contract_upgrade.rs
@@ -184,7 +184,7 @@ mod tests {
             Wormhole,
             (
                 vec![&env, BytesN::<20>::from_array(&env, &[0u8; 20])],
-                BytesN::<32>::from_array(&env, &[1u8; 32]),
+                BytesN::<32>::from_array(&env, &wormhole_soroban_client::GOVERNANCE_EMITTER),
             ),
         );
 

--- a/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
@@ -117,6 +117,12 @@ pub fn set_current_index(env: &Env, index: u32) {
     env.storage()
         .persistent()
         .set(&StorageKey::CurrentGuardianSetIndex, &index);
+
+    env.storage().persistent().extend_ttl(
+        &StorageKey::CurrentGuardianSetIndex,
+        STORAGE_TTL_THRESHOLD,
+        STORAGE_TTL_EXTENSION,
+    );
 }
 
 /// Retrieves a guardian set by index.

--- a/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
@@ -238,7 +238,7 @@ mod tests {
     fn deploy_initialized(env: &Env) -> soroban_sdk::Address {
         let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
         let initial_guardians = vec![env, guardian];
-        let governance_emitter = BytesN::<32>::from_array(env, &[1u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
         env.register(Wormhole, (initial_guardians, governance_emitter))
     }
 
@@ -470,7 +470,7 @@ mod tests {
             Wormhole,
             (
                 vec![&env, guardian_eth],
-                BytesN::<32>::from_array(&env, &[1u8; 32]),
+                BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER),
             ),
         );
         let vaa_bytes = serialize_vaa(&env, &signed);

--- a/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
@@ -68,6 +68,10 @@ impl<'a> TryFrom<(&'a Env, &'a Bytes)> for GuardianSetUpgradePayload {
             keys.push_back(BytesN::from_array(env, &key.to_array()));
         }
 
+        if reader.remaining() != 0 {
+            return Err(WormholeError::InvalidPayload);
+        }
+
         Ok(GuardianSetUpgradePayload {
             module,
             action,

--- a/stellar/contracts/wormhole-contract/src/governance/mod.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/mod.rs
@@ -30,11 +30,7 @@ use wormhole_soroban_client::WormholeError;
 
 /// Checks if a governance VAA has been consumed (replay protection).
 ///
-/// Returns `Ok(())` if not consumed, `Err(GovernanceVAAAlreadyConsumed)` if already used.
-pub fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
-    if action::is_governance_vaa_consumed_from_bytes(&env, &vaa_bytes)? {
-        Err(WormholeError::GovernanceVAAAlreadyConsumed)
-    } else {
-        Ok(())
-    }
+/// Returns `Ok(true)` if consumed, `Ok(false)` if not. Errors only on parse failure.
+pub fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<bool, WormholeError> {
+    action::is_governance_vaa_consumed_from_bytes(&env, &vaa_bytes)
 }

--- a/stellar/contracts/wormhole-contract/src/governance/mod.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/mod.rs
@@ -30,18 +30,7 @@ use wormhole_soroban_client::WormholeError;
 
 /// Checks if a governance VAA has been consumed (replay protection).
 ///
-<<<<<<< fix/wormhole-core
 /// Returns `Ok(true)` if consumed, `Ok(false)` if not. Errors only on parse failure.
 pub fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<bool, WormholeError> {
     action::is_governance_vaa_consumed_from_bytes(&env, &vaa_bytes)
-=======
-/// Returns `Ok(())` if not consumed, `Err(GovernanceVAAAlreadyConsumed)` if
-/// already used.
-pub fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
-    if action::is_governance_vaa_consumed_from_bytes(&env, &vaa_bytes)? {
-        Err(WormholeError::GovernanceVAAAlreadyConsumed)
-    } else {
-        Ok(())
-    }
->>>>>>> stellar
 }

--- a/stellar/contracts/wormhole-contract/src/governance/set_message_fee.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/set_message_fee.rs
@@ -53,6 +53,10 @@ impl<'a> TryFrom<(&'a Env, &'a Bytes)> for SetMessageFeePayload {
         reader.skip(U256_PADDING_BYTES)?;
         let fee = reader.read_u64_be()?;
 
+        if reader.remaining() != 0 {
+            return Err(WormholeError::InvalidPayload);
+        }
+
         Ok(SetMessageFeePayload {
             module,
             action,

--- a/stellar/contracts/wormhole-contract/src/governance/set_message_fee.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/set_message_fee.rs
@@ -119,7 +119,7 @@ mod tests {
     use super::*;
     use crate::Wormhole;
     use soroban_sdk::{Bytes, BytesN, IntoVal, Symbol, testutils::Events, vec};
-    use wormhole_soroban_client::{CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, MODULE_CORE};
+    use wormhole_soroban_client::{CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, MODULE_CORE};
 
     fn build_payload(env: &Env, module: [u8; 32], action: u8, chain: u16, fee: u64) -> Bytes {
         let mut payload = Bytes::new(env);
@@ -134,7 +134,7 @@ mod tests {
     fn deploy_initialized(env: &Env) -> soroban_sdk::Address {
         let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
         let initial_guardians = vec![env, guardian];
-        let governance_emitter = BytesN::<32>::from_array(env, &[1u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
         env.register(Wormhole, (initial_guardians, governance_emitter))
     }
 

--- a/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
@@ -64,6 +64,10 @@ impl<'a> TryFrom<(&'a Env, &'a Bytes)> for TransferFeesPayload {
         let recipient_pk_bytes: BytesN<32> = reader.read_bytes_n::<32>()?;
         let recipient = address_from_ed25519_pk_bytes(env, &recipient_pk_bytes);
 
+        if reader.remaining() != 0 {
+            return Err(WormholeError::InvalidPayload);
+        }
+
         Ok(TransferFeesPayload {
             module,
             action,

--- a/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
@@ -1,8 +1,6 @@
 //! Transfer fees governance action (`ACTION_TRANSFER_FEES`, value 4).
 //!
 //! Allows guardians to withdraw accumulated message fees from the contract.
-//! Validates that sufficient balance remains (≥1 XLM) to prevent Stellar
-//! account deallocation.
 
 use crate::{
     governance::action::{GovernanceAction, parse_governance_header, validate_governance_header},
@@ -12,7 +10,7 @@ use crate::{
 use core::convert::TryFrom;
 use soroban_sdk::{Address, Bytes, BytesN, Env, contractevent, token};
 use wormhole_soroban_client::{
-    ACTION_TRANSFER_FEES, BytesReader, MINIMUM_CONTRACT_BALANCE, STORAGE_TTL_EXTENSION,
+    ACTION_TRANSFER_FEES, BytesReader, STORAGE_TTL_EXTENSION,
     STORAGE_TTL_THRESHOLD, TRANSFER_FEES_PAYLOAD_MIN_LENGTH, U256_PADDING_BYTES, VAA,
     WormholeError,
 };
@@ -88,11 +86,6 @@ impl TransferFeesPayload {
         let current_balance = u64::try_from(token_client.balance(&contract_address)).unwrap_or(0);
 
         if self.amount > current_balance {
-            return Err(WormholeError::InsufficientFees);
-        }
-
-        let remaining_balance = current_balance.saturating_sub(self.amount);
-        if remaining_balance < MINIMUM_CONTRACT_BALANCE {
             return Err(WormholeError::InsufficientFees);
         }
 

--- a/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
@@ -153,9 +153,7 @@ mod tests {
         contracttype,
         testutils::{Address as TestAddress, Events, Ledger},
     };
-    use wormhole_soroban_client::{
-        CHAIN_ID_STELLAR, MINIMUM_CONTRACT_BALANCE, MODULE_CORE, NATIVE_TOKEN_ADDRESS,
-    };
+    use wormhole_soroban_client::{CHAIN_ID_STELLAR, GOVERNANCE_EMITTER, MODULE_CORE, NATIVE_TOKEN_ADDRESS};
 
     #[contracttype]
     #[derive(Clone)]
@@ -202,7 +200,7 @@ mod tests {
     fn deploy_initialized(env: &Env) -> Address {
         let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
         let initial_guardians = soroban_sdk::vec![env, guardian];
-        let governance_emitter = BytesN::<32>::from_array(env, &[1u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
         env.register(Wormhole, (initial_guardians, governance_emitter))
     }
 
@@ -306,26 +304,6 @@ mod tests {
     }
 
     #[test]
-    fn test_transfer_fees_validate_rejects_minimum_balance_violation() {
-        let env = Env::default();
-        let (_native_addr, native_client) = install_native_token_mock(&env);
-        let contract_id = deploy_initialized(&env);
-        env.as_contract(&contract_id, || {
-            native_client.set_balance(&contract_id, &(5 * 10_000_000i128));
-            let recipient = <Address as TestAddress>::generate(&env);
-            let payload = TransferFeesPayload {
-                module: BytesN::from_array(&env, &MODULE_CORE),
-                action: ACTION_TRANSFER_FEES,
-                chain: CHAIN_ID_STELLAR,
-                amount: 5 * 10_000_000,
-                recipient,
-            };
-            let res = payload.validate(&env);
-            assert_eq!(res, Err(WormholeError::InsufficientFees));
-        });
-    }
-
-    #[test]
     fn test_transfer_fees_execute_moves_balance_sets_timestamp_and_emits_event() {
         let env = Env::default();
         env.ledger().set_timestamp(12345);
@@ -384,8 +362,5 @@ mod tests {
                 )
             ]
         );
-
-        // Sanity check critical floor constant is meaningful in this test.
-        assert_eq!(MINIMUM_CONTRACT_BALANCE, 10_000_000);
     }
 }

--- a/stellar/contracts/wormhole-contract/src/initialize.rs
+++ b/stellar/contracts/wormhole-contract/src/initialize.rs
@@ -1,15 +1,12 @@
 //! Contract initialization logic.
 //!
 //! Handles setup of the Wormhole Core contract via the `__constructor` function,
-//! including guardian set creation and governance emitter storage.
+//! including guardian set creation and governance emitter validation.
 //!
 //! This module is only called by the constructor, which is executed atomically
 //! during deployment (Protocol 22+). The runtime guarantees single execution.
 
-use crate::{
-    governance::guardian_set::{set_current_index, store},
-    storage::StorageKey,
-};
+use crate::governance::guardian_set::{set_current_index, store};
 use soroban_sdk::{BytesN, Env, Vec, contractevent};
 use wormhole_soroban_client::*;
 
@@ -30,8 +27,8 @@ struct InitializeEvent {
 
 /// Internal initialization logic called by `__constructor`.
 ///
-/// Sets up the initial guardian set (index 0) and stores the governance emitter
-/// address.
+/// Sets up the initial guardian set (index 0) and validates the governance
+/// emitter against the protocol constant.
 ///
 /// # Arguments
 /// * `initial_guardians` - Ethereum addresses (20 bytes) of initial guardians
@@ -49,17 +46,10 @@ pub(crate) fn initialize_internal(
         env.panic_with_error(WormholeError::EmptyGuardianSet);
     }
 
-    // Store governance emitter address
-    env.storage()
-        .persistent()
-        .set(&StorageKey::GovernanceEmitter, &governance_emitter);
-
-    // Extend TTL for governance emitter (it's permanent config)
-    env.storage().persistent().extend_ttl(
-        &StorageKey::GovernanceEmitter,
-        STORAGE_TTL_THRESHOLD,
-        STORAGE_TTL_EXTENSION,
-    );
+    // Reject deployment with wrong governance emitter
+    if governance_emitter.to_array() != GOVERNANCE_EMITTER {
+        env.panic_with_error(WormholeError::InvalidGovernanceEmitter);
+    }
 
     // Create the initial guardian set (always index 0)
     let guardian_set = GuardianSetInfo {

--- a/stellar/contracts/wormhole-contract/src/initialize.rs
+++ b/stellar/contracts/wormhole-contract/src/initialize.rs
@@ -1,13 +1,7 @@
 //! Contract initialization logic.
 //!
-<<<<<<< fix/wormhole-core
 //! Handles setup of the Wormhole Core contract via the `__constructor` function,
 //! including guardian set creation and governance emitter validation.
-=======
-//! Handles setup of the Wormhole Core contract via the `__constructor`
-//! function, including guardian set creation, admin configuration, and
-//! governance emitter storage.
->>>>>>> stellar
 //!
 //! This module is only called by the constructor, which is executed atomically
 //! during deployment (Protocol 22+). The runtime guarantees single execution.
@@ -33,13 +27,8 @@ struct InitializeEvent {
 
 /// Internal initialization logic called by `__constructor`.
 ///
-<<<<<<< fix/wormhole-core
 /// Sets up the initial guardian set (index 0) and validates the governance
 /// emitter against the protocol constant.
-=======
-/// Sets up the initial guardian set (index 0), configures the contract as its
-/// own admin for upgrades, and stores the governance emitter address.
->>>>>>> stellar
 ///
 /// # Arguments
 /// * `initial_guardians` - Ethereum addresses (20 bytes) of initial guardians
@@ -96,7 +85,7 @@ mod tests {
         let env = Env::default();
         let guardian = BytesN::from_array(&env, &[0u8; 20]);
         let initial_guardians = vec![&env, guardian.clone()];
-        let governance_emitter = BytesN::from_array(&env, &[1u8; 32]);
+        let governance_emitter = BytesN::from_array(&env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(
             Wormhole,
             (initial_guardians.clone(), governance_emitter.clone()),
@@ -104,21 +93,15 @@ mod tests {
         let client = WormholeClient::new(&env, &contract_id);
 
         assert_eq!(client.get_current_guardian_set_index(), 0);
-        assert_eq!(client.get_governance_emitter(), governance_emitter);
+        assert_eq!(
+            client.get_governance_emitter(),
+            BytesN::from_array(&env, &GOVERNANCE_EMITTER)
+        );
         let guardian_set = client.get_guardian_set(&0);
         assert_eq!(guardian_set.keys.len(), 1);
         assert_eq!(guardian_set.keys.get(0).unwrap(), guardian);
 
         assert_eq!(guardian_set.creation_time, env.ledger().timestamp());
-
-        env.as_contract(&contract_id, || {
-            let admin: soroban_sdk::Address = env
-                .storage()
-                .instance()
-                .get(&crate::storage::StorageKey::Admin)
-                .unwrap();
-            assert_eq!(admin, env.current_contract_address());
-        });
     }
 
     #[test]
@@ -133,7 +116,7 @@ mod tests {
             guardian_2.clone(),
             guardian_3.clone(),
         ];
-        let governance_emitter = BytesN::from_array(&env, &[9u8; 32]);
+        let governance_emitter = BytesN::from_array(&env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter));
         let client = WormholeClient::new(&env, &contract_id);
 
@@ -149,7 +132,7 @@ mod tests {
     fn test_constructor_rejects_empty_guardians() {
         let env = Env::default();
         let initial_guardians: Vec<BytesN<20>> = Vec::new(&env);
-        let governance_emitter = BytesN::from_array(&env, &[1u8; 32]);
+        let governance_emitter = BytesN::from_array(&env, &GOVERNANCE_EMITTER);
 
         let _ = env.register(Wormhole, (initial_guardians, governance_emitter));
     }
@@ -159,7 +142,7 @@ mod tests {
         let env = Env::default();
         let guardian = BytesN::from_array(&env, &[0u8; 20]);
         let initial_guardians = vec![&env, guardian.clone()];
-        let governance_emitter = BytesN::from_array(&env, &[1u8; 32]);
+        let governance_emitter = BytesN::from_array(&env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter));
 
         let all_events = env.events().all();
@@ -167,7 +150,8 @@ mod tests {
         assert_eq!(contract_events.events().len(), 1);
         let chain_id_val: Val = 61u32.into_val(&env);
         let governance_chain_id_val: Val = 1u32.into_val(&env);
-        let governance_emitter_val: Val = BytesN::from_array(&env, &[1u8; 32]).into_val(&env);
+        let governance_emitter_val: Val =
+            BytesN::from_array(&env, &GOVERNANCE_EMITTER).into_val(&env);
         let guardian_count_val: Val = 1u32.into_val(&env);
 
         assert_eq!(

--- a/stellar/contracts/wormhole-contract/src/initialize.rs
+++ b/stellar/contracts/wormhole-contract/src/initialize.rs
@@ -1,7 +1,7 @@
 //! Contract initialization logic.
 //!
 //! Handles setup of the Wormhole Core contract via the `__constructor` function,
-//! including guardian set creation, admin configuration, and governance emitter storage.
+//! including guardian set creation and governance emitter storage.
 //!
 //! This module is only called by the constructor, which is executed atomically
 //! during deployment (Protocol 22+). The runtime guarantees single execution.
@@ -30,8 +30,8 @@ struct InitializeEvent {
 
 /// Internal initialization logic called by `__constructor`.
 ///
-/// Sets up the initial guardian set (index 0), configures the contract as its own
-/// admin for upgrades, and stores the governance emitter address.
+/// Sets up the initial guardian set (index 0) and stores the governance emitter
+/// address.
 ///
 /// # Arguments
 /// * `initial_guardians` - Ethereum addresses (20 bytes) of initial guardians
@@ -48,12 +48,6 @@ pub(crate) fn initialize_internal(
     if initial_guardians.is_empty() {
         env.panic_with_error(WormholeError::EmptyGuardianSet);
     }
-
-    // Set contract as its own admin for upgrades
-    let contract_address = env.current_contract_address();
-    env.storage()
-        .instance()
-        .set(&StorageKey::Admin, &contract_address);
 
     // Store governance emitter address
     env.storage()

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -22,7 +22,7 @@ use crate::governance::{
 };
 use soroban_sdk::{Address, Bytes, BytesN, Env, Vec, contract, contractimpl};
 use wormhole_soroban_client::{
-    CHAIN_ID_STELLAR, ConsistencyLevel, GOVERNANCE_CHAIN_ID, GuardianSetInfo,
+    CHAIN_ID_STELLAR, ConsistencyLevel, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, GuardianSetInfo,
     WormholeCoreInterface, WormholeError,
 };
 
@@ -155,10 +155,6 @@ impl WormholeCoreInterface for Wormhole {
     }
 
     fn get_governance_emitter(env: Env) -> BytesN<32> {
-        // Constructor guarantees this is always set
-        env.storage()
-            .persistent()
-            .get(&storage::StorageKey::GovernanceEmitter)
-            .expect("governance emitter not set")
+        BytesN::from_array(&env, &GOVERNANCE_EMITTER)
     }
 }

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
     fn deploy_initialized(env: &Env) -> (Address, WormholeClient<'_>) {
         let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
         let initial_guardians = vec![env, guardian];
-        let governance_emitter = BytesN::<32>::from_array(env, &[1u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter));
         let client = WormholeClient::new(env, &contract_id);
         (contract_id, client)
@@ -220,14 +220,11 @@ mod tests {
     }
 
     #[test]
-    fn test_get_governance_emitter_roundtrip() {
+    fn test_get_governance_emitter_returns_const() {
         let env = Env::default();
-        let guardian = BytesN::<20>::from_array(&env, &[0u8; 20]);
-        let initial_guardians = vec![&env, guardian];
-        let governance_emitter = BytesN::<32>::from_array(&env, &[9u8; 32]);
-        let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter.clone()));
-        let client = WormholeClient::new(&env, &contract_id);
-        assert_eq!(client.get_governance_emitter(), governance_emitter);
+        let (_contract_id, client) = deploy_initialized(&env);
+        let expected = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
+        assert_eq!(client.get_governance_emitter(), expected);
     }
 
     #[test]

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -45,8 +45,7 @@ pub struct Wormhole;
 impl Wormhole {
     /// Constructor called atomically during contract deployment.
     ///
-    /// Sets up the initial guardian set (index 0), configures the contract as
-    /// its own admin for governance upgrades, and stores the governance
+    /// Sets up the initial guardian set (index 0) and stores the governance
     /// emitter address.
     ///
     /// # Arguments

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -149,7 +149,7 @@ impl WormholeCoreInterface for Wormhole {
         token_client.balance(&env.current_contract_address())
     }
 
-    fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
+    fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<bool, WormholeError> {
         governance::is_governance_vaa_consumed(env, vaa_bytes)
     }
 

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -80,6 +80,13 @@ impl WormholeCoreInterface for Wormhole {
         vaa::parse_vaa(&env, &vaa_bytes)
     }
 
+    fn parse_and_verify_vaa(
+        env: Env,
+        vaa_bytes: Bytes,
+    ) -> Result<wormhole_soroban_client::VAA, WormholeError> {
+        vaa::parse_and_verify_vaa(&env, &vaa_bytes)
+    }
+
     fn submit_contract_upgrade(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
         ContractUpgradeAction::submit(&env, vaa_bytes)
     }

--- a/stellar/contracts/wormhole-contract/src/message.rs
+++ b/stellar/contracts/wormhole-contract/src/message.rs
@@ -138,6 +138,12 @@ pub fn post_message_with_fee(
     let required_fee = governance::get_message_fee(env);
 
     if required_fee > 0 {
+        env.storage().persistent().extend_ttl(
+            &StorageKey::MessageFee,
+            STORAGE_TTL_THRESHOLD,
+            STORAGE_TTL_EXTENSION,
+        );
+
         let native_token = get_native_token_address(env);
         let token_client = token::TokenClient::new(env, &native_token);
         let contract = env.current_contract_address();

--- a/stellar/contracts/wormhole-contract/src/message.rs
+++ b/stellar/contracts/wormhole-contract/src/message.rs
@@ -209,11 +209,12 @@ mod tests {
 
     use super::*;
     use crate::{Wormhole, WormholeClient};
+    use wormhole_soroban_client::GOVERNANCE_EMITTER;
 
     fn deploy_initialized(env: &Env) -> (Address, WormholeClient<'_>) {
         let guardian = BytesN::from_array(env, &[0u8; 20]);
         let initial_guardians = vec![env, guardian];
-        let governance_emitter = BytesN::from_array(env, &[1u8; 32]);
+        let governance_emitter = BytesN::from_array(env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter));
         let client = WormholeClient::new(env, &contract_id);
         (contract_id, client)

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -14,8 +14,6 @@ use soroban_sdk::{Address, BytesN, contracttype};
 pub enum StorageKey {
     /// Index of the currently active guardian set (starts at 0).
     CurrentGuardianSetIndex,
-    /// 32-byte address authorized to emit governance VAAs.
-    GovernanceEmitter,
     /// Guardian set data keyed by index; stores `GuardianSetInfo`.
     GuardianSet(u32),
     /// Unix timestamp when a guardian set expires (24h after replacement).

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -16,14 +16,6 @@ use soroban_sdk::{Address, BytesN, contracttype};
 pub enum StorageKey {
     /// Index of the currently active guardian set (starts at 0).
     CurrentGuardianSetIndex,
-<<<<<<< fix/wormhole-core
-=======
-    /// Contract's admin address (set to itself for self-upgrade via
-    /// governance).
-    Admin,
-    /// 32-byte address authorized to emit governance VAAs.
-    GovernanceEmitter,
->>>>>>> stellar
     /// Guardian set data keyed by index; stores `GuardianSetInfo`.
     GuardianSet(u32),
     /// Unix timestamp when a guardian set expires (24h after replacement).

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -14,8 +14,6 @@ use soroban_sdk::{Address, BytesN, contracttype};
 pub enum StorageKey {
     /// Index of the currently active guardian set (starts at 0).
     CurrentGuardianSetIndex,
-    /// Contract's admin address (set to itself for self-upgrade via governance).
-    Admin,
     /// 32-byte address authorized to emit governance VAAs.
     GovernanceEmitter,
     /// Guardian set data keyed by index; stores `GuardianSetInfo`.

--- a/stellar/contracts/wormhole-contract/src/vaa.rs
+++ b/stellar/contracts/wormhole-contract/src/vaa.rs
@@ -114,12 +114,24 @@ fn verify_signatures_impl(
     Ok(true)
 }
 
-/// Parses and verifies a VAA in a single call.
+/// Parses a VAA and verifies all guardian signatures in a single call.
 ///
-/// Combines `VAA::try_from` parsing with full signature verification.
-pub fn verify_vaa(env: &Env, vaa_bytes: &Bytes) -> Result<bool, WormholeError> {
+/// This is the primary entry point for external integrators who need both
+/// parsing and verification. Avoids the double parse that occurs when
+/// calling `verify_vaa` and `parse_vaa` separately.
+pub fn parse_and_verify_vaa(env: &Env, vaa_bytes: &Bytes) -> Result<VAA, WormholeError> {
     let vaa = VAA::try_from((env, vaa_bytes))?;
-    verify_vaa_signatures(&vaa, env)
+    verify_vaa_signatures(&vaa, env)?;
+    Ok(vaa)
+}
+
+/// Verifies a VAA's guardian signatures, returning success or an error.
+///
+/// Parses and verifies internally. For callers that also need the parsed
+/// VAA, use [`parse_and_verify_vaa`] instead to avoid a double parse.
+pub fn verify_vaa(env: &Env, vaa_bytes: &Bytes) -> Result<(), WormholeError> {
+    parse_and_verify_vaa(env, vaa_bytes)?;
+    Ok(())
 }
 
 /// Parses VAA bytes into a structured `VAA` without signature verification.

--- a/stellar/contracts/wormhole-contract/src/vaa.rs
+++ b/stellar/contracts/wormhole-contract/src/vaa.rs
@@ -147,12 +147,12 @@ pub fn parse_vaa(env: &Env, vaa_bytes: &Bytes) -> Result<VAA, WormholeError> {
 mod tests {
     use super::*;
     use soroban_sdk::{testutils::Ledger, vec};
-    use wormhole_soroban_client::ConsistencyLevel;
+    use wormhole_soroban_client::{ConsistencyLevel, GOVERNANCE_EMITTER};
 
     fn deploy_initialized(env: &Env) -> (soroban_sdk::Address, crate::WormholeClient<'_>) {
         let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
         let initial_guardians = vec![env, guardian];
-        let governance_emitter = BytesN::<32>::from_array(env, &[1u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
         let client = crate::WormholeClient::new(env, &contract_id);
         (contract_id, client)
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn test_verify_vaa_insufficient_sigs() {
         let env = Env::default();
-        let governance_emitter = BytesN::<32>::from_array(&env, &[9u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
 
         let g0 = BytesN::<20>::from_array(&env, &[0u8; 20]);
         let g1 = BytesN::<20>::from_array(&env, &[1u8; 20]);
@@ -407,7 +407,7 @@ mod tests {
         let env = Env::default();
         let stored_guardian = BytesN::<20>::from_array(&env, &[0x11u8; 20]);
         let initial_guardians = soroban_sdk::vec![&env, stored_guardian];
-        let governance_emitter = BytesN::<32>::from_array(&env, &[0x22u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
 
         let base_vaa = VAA {
@@ -474,7 +474,7 @@ mod tests {
         vaa.signatures = sigs;
 
         let initial_guardians = soroban_sdk::vec![&env, valid_eth_address];
-        let governance_emitter = BytesN::<32>::from_array(&env, &[0x22u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
 
         env.as_contract(&contract_id, || {
@@ -540,7 +540,7 @@ mod tests {
         let base_vaa = base_vaa_with_guardian_set(&env, 0);
         let (sig, guardian_eth) = sign_for_vaa(&env, &base_vaa, [0x77u8; 32], 1);
         let initial_guardians = soroban_sdk::vec![&env, guardian_eth.clone(), guardian_eth];
-        let governance_emitter = BytesN::<32>::from_array(&env, &[0x22u8; 32]);
+        let governance_emitter = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
         let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
 
         let mut vaa = base_vaa.clone();

--- a/stellar/contracts/wormhole-soroban-client/src/constants.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/constants.rs
@@ -57,13 +57,7 @@ pub const ACTION_SET_MESSAGE_FEE: u8 = 3;
 /// Action ID for transferring accumulated fees (governance action 4).
 pub const ACTION_TRANSFER_FEES: u8 = 4;
 
-// ========== Balance & Token Constants ==========
-
-/// Minimum XLM balance the contract must retain (1 XLM = 10^7 stroops).
-///
-/// Stellar accounts are deallocated if their balance drops below the base reserve.
-/// This constant ensures fee transfers never drain the contract below a safe threshold.
-pub const MINIMUM_CONTRACT_BALANCE: u64 = 10_000_000;
+// ========== Token Constants ==========
 
 /// Native XLM token symbol for Stellar Asset Contract.
 pub const NATIVE_TOKEN_SYMBOL: &str = "native";

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -267,7 +267,7 @@ pub trait WormholeCoreInterface {
     ///
     /// # Errors
     /// * `Error::InvalidVAAFormat` - Malformed VAA bytes
-    fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError>;
+    fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<bool, WormholeError>;
 
     // ========== Protocol Constants ==========
 

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -89,6 +89,26 @@ pub trait WormholeCoreInterface {
     /// * `Error::InvalidVAAFormat` - Malformed VAA bytes
     fn parse_vaa(env: Env, vaa_bytes: Bytes) -> Result<VAA, WormholeError>;
 
+    /// Parse and verify a VAA in a single call.
+    ///
+    /// Equivalent to calling `verify_vaa` then `parse_vaa`, but parses the
+    /// VAA only once. This is the recommended entry point for integrators
+    /// who need both the parsed structure and signature verification.
+    ///
+    /// # Arguments
+    /// * `vaa_bytes` - Serialized VAA bytes
+    ///
+    /// # Returns
+    /// Parsed and verified VAA structure
+    ///
+    /// # Errors
+    /// * `Error::InvalidVAAFormat` - Malformed VAA bytes
+    /// * `Error::GuardianSetNotFound` - Guardian set not found
+    /// * `Error::GuardianSetExpired` - Guardian set has expired
+    /// * `Error::InsufficientSignatures` - Not enough signatures for quorum
+    /// * `Error::InvalidSignature` - Invalid guardian signature
+    fn parse_and_verify_vaa(env: Env, vaa_bytes: Bytes) -> Result<VAA, WormholeError>;
+
     // ========== Governance Actions ==========
 
     /// Submit a contract upgrade governance VAA.

--- a/stellar/contracts/wormhole-soroban-client/src/types.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/types.rs
@@ -174,6 +174,9 @@ impl<'a> TryFrom<(&'a Env, &'a Bytes)> for VAA {
         let mut reader = BytesReader::new(vaa_bytes);
 
         let version = u32::from(reader.read_u8()?);
+        if version != 1 {
+            return Err(WormholeError::InvalidVAAFormat);
+        }
         let guardian_set_index = reader.read_u32_be()?;
         let num_signatures = u32::from(reader.read_u8()?);
 


### PR DESCRIPTION
## Summary

Implements all 11 fixes from Wormhole team review feedback on the Stellar core contract.

1. **Trailing bytes check** — All four governance payload parsers now reject payloads with extra bytes after parsing, matching EVM/Solana behavior.
2. **CurrentGuardianSetIndex TTL** — `set_current_index` now extends TTL on write, preventing the contract from becoming non-functional if the entry gets archived.
3. **Remove StorageKey::Admin** — Removed dead admin storage key and its write in initialization; Soroban's `update_current_contract_wasm` doesn't use it.
4. **Remove governance_emitter storage** — Getter now returns the `GOVERNANCE_EMITTER` const directly; constructor validates the param matches the const instead of persisting it.
5. **MessageFee TTL on read** — `post_message_with_fee` now extends the MessageFee TTL when fee is non-zero, preventing silent fallback to free messaging.
6. **Eliminate double VAA parsing in governance** — `verify_and_hash_governance_vaa` now calls `verify_vaa_signatures` directly instead of `verify_vaa`, which was internally re-parsing the VAA.
7. **Fix is_governance_vaa_consumed return type** — Changed from `Result<(), WormholeError>` to `Result<bool, WormholeError>`; errors are now reserved for parse failures only.
8. **Add parse_and_verify_vaa** — New combined trait method and implementation matching EVM's `parseAndVerifyVM`; `verify_vaa` now delegates to it internally.
9. **VAA version check** — `VAA::try_from` now rejects VAAs with version != 1, matching EVM.
10. **Remove MINIMUM_CONTRACT_BALANCE** — Removed the 1 XLM minimum balance check from `transfer_fees`; Soroban contracts cannot be deallocated for having zero XLM.
11. **Remove TTL extension from consume_vaa** — Persistent storage archival already provides replay protection; the `extend_ttl` was unnecessary cost.
