### PR TITLE
Remove Stellar-only convenience getters and unnecessary storage

### DIFF
--- a/stellar/ARCHITECTURE.md
+++ b/stellar/ARCHITECTURE.md
@@ -84,7 +84,6 @@ fn get_guardian_set(env: Env, index: u32) -> Result<GuardianSetInfo, WormholeErr
 fn get_guardian_set_expiry(env: Env, index: u32) -> Option<u64>;
 fn get_message_fee(env: Env) -> u64;
 fn get_emitter_sequence(env: Env, emitter: Address) -> u64;
-fn get_last_fee_transfer(env: Env) -> Option<u64>;
 fn get_contract_balance(env: Env) -> i128;
 fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError>;
 fn get_chain_id() -> u32;

--- a/stellar/ARCHITECTURE.md
+++ b/stellar/ARCHITECTURE.md
@@ -84,7 +84,6 @@ fn get_guardian_set(env: Env, index: u32) -> Result<GuardianSetInfo, WormholeErr
 fn get_guardian_set_expiry(env: Env, index: u32) -> Option<u64>;
 fn get_message_fee(env: Env) -> u64;
 fn get_emitter_sequence(env: Env, emitter: Address) -> u64;
-fn get_contract_balance(env: Env) -> i128;
 fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError>;
 fn get_chain_id() -> u32;
 fn get_governance_chain_id() -> u32;

--- a/stellar/ARCHITECTURE.md
+++ b/stellar/ARCHITECTURE.md
@@ -84,7 +84,6 @@ fn get_guardian_set(env: Env, index: u32) -> Result<GuardianSetInfo, WormholeErr
 fn get_guardian_set_expiry(env: Env, index: u32) -> Option<u64>;
 fn get_message_fee(env: Env) -> u64;
 fn get_emitter_sequence(env: Env, emitter: Address) -> u64;
-fn get_posted_message_hash(env: Env, emitter: Address, sequence: u64) -> Option<BytesN<32>>;
 fn get_last_fee_transfer(env: Env) -> Option<u64>;
 fn get_contract_balance(env: Env) -> i128;
 fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError>;

--- a/stellar/contracts/wormhole-contract/src/governance/mod.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/mod.rs
@@ -23,7 +23,7 @@ pub use action::GovernanceAction;
 pub use contract_upgrade::ContractUpgradeAction;
 pub use guardian_set::GuardianSetUpgradeAction;
 pub use set_message_fee::{SetMessageFeeAction, get_message_fee};
-pub use transfer_fees::{TransferFeesAction, get_last_fee_transfer};
+pub use transfer_fees::TransferFeesAction;
 
 use soroban_sdk::{Bytes, Env};
 use wormhole_soroban_client::WormholeError;

--- a/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
@@ -4,14 +4,12 @@
 
 use crate::{
     governance::action::{GovernanceAction, parse_governance_header, validate_governance_header},
-    storage::StorageKey,
     utils::{address_from_ed25519_pk_bytes, get_native_token_address},
 };
 use core::convert::TryFrom;
 use soroban_sdk::{Address, Bytes, BytesN, Env, contractevent, token};
 use wormhole_soroban_client::{
-    ACTION_TRANSFER_FEES, BytesReader, STORAGE_TTL_EXTENSION,
-    STORAGE_TTL_THRESHOLD, TRANSFER_FEES_PAYLOAD_MIN_LENGTH, U256_PADDING_BYTES, VAA,
+    ACTION_TRANSFER_FEES, BytesReader, TRANSFER_FEES_PAYLOAD_MIN_LENGTH, U256_PADDING_BYTES, VAA,
     WormholeError,
 };
 
@@ -94,23 +92,6 @@ impl TransferFeesPayload {
     }
 }
 
-/// Returns the timestamp of the most recent fee transfer, if any.
-pub fn get_last_fee_transfer(env: &Env) -> Option<u64> {
-    env.storage().persistent().get(&StorageKey::LastFeeTransfer)
-}
-
-fn set_last_fee_transfer(env: &Env, timestamp: u64) {
-    env.storage()
-        .persistent()
-        .set(&StorageKey::LastFeeTransfer, &timestamp);
-
-    env.storage().persistent().extend_ttl(
-        &StorageKey::LastFeeTransfer,
-        STORAGE_TTL_THRESHOLD,
-        STORAGE_TTL_EXTENSION,
-    );
-}
-
 /// Governance action handler for fee transfers.
 pub struct TransferFeesAction;
 
@@ -131,8 +112,6 @@ impl GovernanceAction for TransferFeesAction {
             &payload.recipient,
             &i128::from(payload.amount),
         );
-
-        set_last_fee_transfer(env, env.ledger().timestamp());
 
         FeeTransferEvent {
             amount: payload.amount,
@@ -304,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn test_transfer_fees_execute_moves_balance_sets_timestamp_and_emits_event() {
+    fn test_transfer_fees_execute_moves_balance_and_emits_event() {
         let env = Env::default();
         env.ledger().set_timestamp(12345);
         let (_native_addr, native_client) = install_native_token_mock(&env);
@@ -336,7 +315,6 @@ mod tests {
 
             assert_eq!(native_client.balance(&contract_id), 15 * 10_000_000i128);
             assert_eq!(native_client.balance(&recipient), 5 * 10_000_000i128);
-            assert_eq!(get_last_fee_transfer(&env), Some(12345));
         });
 
         let events = env.events().all().filter_by_contract(&contract_id);

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -135,10 +135,6 @@ impl WormholeCoreInterface for Wormhole {
         governance::get_message_fee(&env)
     }
 
-    fn get_last_fee_transfer(env: Env) -> Option<u64> {
-        governance::get_last_fee_transfer(&env)
-    }
-
     fn get_contract_balance(env: Env) -> i128 {
         let native_token_address = utils::get_native_token_address(&env);
         let token_client = soroban_sdk::token::TokenClient::new(&env, &native_token_address);
@@ -283,10 +279,9 @@ mod tests {
     }
 
     #[test]
-    fn test_get_last_fee_transfer_default_none_and_guardian_expiry_none() {
+    fn test_guardian_set_expiry_default_none() {
         let env = Env::default();
         let (_contract_id, client) = deploy_initialized(&env);
-        assert_eq!(client.get_last_fee_transfer(), None);
         assert_eq!(client.get_guardian_set_expiry(&0), None);
     }
 }

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -135,12 +135,6 @@ impl WormholeCoreInterface for Wormhole {
         governance::get_message_fee(&env)
     }
 
-    fn get_contract_balance(env: Env) -> i128 {
-        let native_token_address = utils::get_native_token_address(&env);
-        let token_client = soroban_sdk::token::TokenClient::new(&env, &native_token_address);
-        token_client.balance(&env.current_contract_address())
-    }
-
     fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<bool, WormholeError> {
         governance::is_governance_vaa_consumed(env, vaa_bytes)
     }

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -131,10 +131,6 @@ impl WormholeCoreInterface for Wormhole {
         message::get_emitter_sequence(&env, &emitter)
     }
 
-    fn get_posted_message_hash(env: Env, emitter: Address, sequence: u64) -> Option<BytesN<32>> {
-        message::get_posted_message_hash(&env, &emitter, sequence)
-    }
-
     fn get_message_fee(env: Env) -> u64 {
         governance::get_message_fee(&env)
     }

--- a/stellar/contracts/wormhole-contract/src/message.rs
+++ b/stellar/contracts/wormhole-contract/src/message.rs
@@ -7,15 +7,10 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, address_payload::AddressPayload, contractevent, token,
 };
 use wormhole_soroban_client::{
-    CHAIN_ID_STELLAR, ConsistencyLevel, PostedMessageData, STORAGE_TTL_EXTENSION,
-    STORAGE_TTL_THRESHOLD, WormholeError,
+    ConsistencyLevel, STORAGE_TTL_EXTENSION, STORAGE_TTL_THRESHOLD, WormholeError,
 };
 
-use crate::{
-    governance,
-    storage::StorageKey,
-    utils::{get_native_token_address, keccak256_hash},
-};
+use crate::{governance, storage::StorageKey, utils::get_native_token_address};
 
 /// Emitted when a cross-chain message is posted successfully.
 ///
@@ -36,58 +31,12 @@ struct MessagePublishedEvent {
     consistency_level: ConsistencyLevel,
 }
 
-/// Serializes message data to bytes for hashing (51-byte header + payload).
-fn serialize_posted_message(
-    message: &PostedMessageData,
-    env: &Env,
-) -> Result<Bytes, WormholeError> {
-    // Build fixed-size header as a single array (51 bytes)
-    let mut header = [0u8; 51];
-    let mut offset = 0;
-
-    // timestamp (4 bytes, big-endian)
-    header[offset..offset + 4].copy_from_slice(&message.timestamp.to_be_bytes());
-    offset += 4;
-
-    // nonce (4 bytes, big-endian)
-    header[offset..offset + 4].copy_from_slice(&message.nonce.to_be_bytes());
-    offset += 4;
-
-    // emitter_chain (2 bytes, big-endian u16)
-    header[offset..offset + 2].copy_from_slice(&(message.emitter_chain as u16).to_be_bytes());
-    offset += 2;
-
-    // emitter_address (32 bytes)
-    header[offset..offset + 32].copy_from_slice(&message.emitter_address.to_array());
-    offset += 32;
-
-    // sequence (8 bytes, big-endian)
-    header[offset..offset + 8].copy_from_slice(&message.sequence.to_be_bytes());
-    offset += 8;
-
-    // consistency_level (1 byte)
-    header[offset] = message.consistency_level as u8;
-
-    // Create Bytes from header and append payload in a single operation
-    let mut bytes = Bytes::from_array(env, &header);
-    bytes.append(&message.payload);
-
-    Ok(bytes)
-}
-
 /// Returns the next sequence number for an emitter (0 if never used).
 pub fn get_emitter_sequence(env: &Env, emitter: &Address) -> u64 {
     env.storage()
         .persistent()
         .get(&StorageKey::EmitterSequence(emitter.clone()))
         .unwrap_or(0)
-}
-
-/// Retrieves a previously posted message's hash by emitter and sequence.
-pub fn get_posted_message_hash(env: &Env, emitter: &Address, sequence: u64) -> Option<BytesN<32>> {
-    env.storage()
-        .persistent()
-        .get(&StorageKey::PostedMessage(emitter.clone(), sequence))
 }
 
 /// Atomically increments and returns the current sequence for an emitter.
@@ -107,25 +56,11 @@ fn next_emitter_sequence(env: &Env, emitter: &Address) -> u64 {
     current
 }
 
-/// Persists a message hash keyed by (emitter, sequence).
-fn store_posted_message(env: &Env, emitter: &Address, sequence: u64, message_hash: &BytesN<32>) {
-    env.storage().persistent().set(
-        &StorageKey::PostedMessage(emitter.clone(), sequence),
-        message_hash,
-    );
-
-    env.storage().persistent().extend_ttl(
-        &StorageKey::PostedMessage(emitter.clone(), sequence),
-        STORAGE_TTL_THRESHOLD,
-        STORAGE_TTL_EXTENSION,
-    );
-}
-
 /// Posts a cross-chain message with optional fee collection.
 ///
 /// Collects the configured message fee (if any) via `transfer_from`, assigns
-/// a sequence number, hashes and stores the message, then emits a
-/// `MessagePublishedEvent` for guardian observation.
+/// a sequence number, then emits a `MessagePublishedEvent` for guardian
+/// observation.
 ///
 /// # Errors
 ///
@@ -169,21 +104,6 @@ pub fn post_message_with_fee(
         Some(AddressPayload::ContractIdHash(contract_id)) => contract_id,
         _ => return Err(WormholeError::InvalidEmitterAddress),
     };
-
-    let message_data = PostedMessageData {
-        timestamp: u32::try_from(env.ledger().timestamp()).unwrap_or(0),
-        nonce,
-        emitter_chain: u32::from(CHAIN_ID_STELLAR),
-        emitter_address: emitter_bytes.clone(),
-        sequence,
-        consistency_level,
-        payload: payload.clone(),
-    };
-
-    let message_bytes = serialize_posted_message(&message_data, env)?;
-    let hash_bytes = keccak256_hash(env, &message_bytes);
-
-    store_posted_message(env, emitter, sequence, &hash_bytes);
 
     MessagePublishedEvent {
         nonce,
@@ -275,14 +195,10 @@ mod tests {
 
         env.mock_all_auths();
 
-        // `post_message` only accepts contract emitters.
         let emitter = contract_id.clone();
         let nonce = runtime_test_nonce(&env);
         let payload = Bytes::from_array(&env, &[0xAA, 0xBB, 0xCC]);
         let cl = ConsistencyLevel::Confirmed;
-
-        let ts_u32 = u32::try_from(env.ledger().timestamp()).unwrap_or(0);
-        let emitter_bytes32 = address_to_bytes32(&emitter);
 
         let seq0 = client.post_message(&emitter, &nonce, &payload, &cl);
         assert_eq!(seq0, 0);
@@ -290,29 +206,6 @@ mod tests {
         let events = env.events().all().filter_by_contract(&contract_id);
         assert_eq!(events.events().len(), 1);
         assert_eq!(client.get_emitter_sequence(&emitter), 1);
-
-        let stored_hash0 = client
-            .get_posted_message_hash(&emitter, &0)
-            .expect("missing hash");
-
-        let mut header = [0u8; 51];
-        let mut off = 0usize;
-        header[off..off + 4].copy_from_slice(&ts_u32.to_be_bytes());
-        off += 4;
-        header[off..off + 4].copy_from_slice(&nonce.to_be_bytes());
-        off += 4;
-        header[off..off + 2].copy_from_slice(&CHAIN_ID_STELLAR.to_be_bytes());
-        off += 2;
-        header[off..off + 32].copy_from_slice(&emitter_bytes32.to_array());
-        off += 32;
-        header[off..off + 8].copy_from_slice(&0u64.to_be_bytes());
-        off += 8;
-        header[off] = cl as u8;
-
-        let mut msg_bytes = Bytes::from_array(&env, &header);
-        msg_bytes.append(&payload);
-        let expected_hash0 = keccak256_hash(&env, &msg_bytes);
-        assert_eq!(stored_hash0, expected_hash0);
 
         let seq1 = client.post_message(&emitter, &nonce, &payload, &cl);
         assert_eq!(seq1, 1);
@@ -396,7 +289,6 @@ mod tests {
         );
         assert_eq!(res, Err(Ok(WormholeError::InsufficientFeePaid)));
         assert_eq!(client.get_emitter_sequence(&emitter), 0);
-        assert!(client.get_posted_message_hash(&emitter, &0).is_none());
     }
 
     #[test]
@@ -450,44 +342,4 @@ mod tests {
         assert_eq!(client.get_emitter_sequence(&emitter), 3);
     }
 
-    #[test]
-    fn test_posted_message_hash_stored() {
-        let env = Env::default();
-        let (contract_id, client) = deploy_initialized(&env);
-        env.mock_all_auths();
-
-        let emitter = contract_id.clone();
-        let nonce = runtime_test_nonce(&env);
-        let payload = Bytes::from_array(&env, &[0xAA, 0xBB, 0xCC]);
-        let cl = ConsistencyLevel::Confirmed;
-        let ts_u32 = u32::try_from(env.ledger().timestamp()).unwrap_or(0);
-
-        let seq = client.post_message(&emitter, &nonce, &payload, &cl);
-        assert_eq!(seq, 0);
-
-        let stored = client
-            .get_posted_message_hash(&emitter, &seq)
-            .expect("missing stored hash");
-        let emitter_bytes32 = address_to_bytes32(&emitter);
-
-        let mut header = [0u8; 51];
-        let mut off = 0usize;
-        header[off..off + 4].copy_from_slice(&ts_u32.to_be_bytes());
-        off += 4;
-        header[off..off + 4].copy_from_slice(&nonce.to_be_bytes());
-        off += 4;
-        header[off..off + 2].copy_from_slice(&CHAIN_ID_STELLAR.to_be_bytes());
-        off += 2;
-        header[off..off + 32].copy_from_slice(&emitter_bytes32.to_array());
-        off += 32;
-        header[off..off + 8].copy_from_slice(&seq.to_be_bytes());
-        off += 8;
-        header[off] = cl as u8;
-
-        let mut msg_bytes = Bytes::from_array(&env, &header);
-        msg_bytes.append(&payload);
-        let expected = keccak256_hash(&env, &msg_bytes);
-
-        assert_eq!(stored, expected);
-    }
 }

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -28,6 +28,4 @@ pub enum StorageKey {
     LastFeeTransfer,
     /// Next sequence number for each emitter address.
     EmitterSequence(Address),
-    /// Hash of posted message keyed by (emitter, sequence).
-    PostedMessage(Address, u64),
 }

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -24,8 +24,6 @@ pub enum StorageKey {
     ConsumedGovernanceVAA(BytesN<32>),
     /// Fee charged per message in stroops (10^-7 XLM).
     MessageFee,
-    /// Timestamp of the most recent fee transfer (audit trail).
-    LastFeeTransfer,
     /// Next sequence number for each emitter address.
     EmitterSequence(Address),
 }

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -235,12 +235,6 @@ pub trait WormholeCoreInterface {
     /// Message fee in stroops
     fn get_message_fee(env: Env) -> u64;
 
-    /// Get the contract's current XLM balance.
-    ///
-    /// # Returns
-    /// Balance in stroops
-    fn get_contract_balance(env: Env) -> i128;
-
     /// Check if a governance VAA has been consumed (replay protection).
     ///
     /// # Arguments

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -235,12 +235,6 @@ pub trait WormholeCoreInterface {
     /// Message fee in stroops
     fn get_message_fee(env: Env) -> u64;
 
-    /// Get the timestamp of the last fee transfer.
-    ///
-    /// # Returns
-    /// Timestamp of last transfer, or None if never transferred
-    fn get_last_fee_transfer(env: Env) -> Option<u64>;
-
     /// Get the contract's current XLM balance.
     ///
     /// # Returns

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -229,16 +229,6 @@ pub trait WormholeCoreInterface {
     /// Next sequence number for the emitter
     fn get_emitter_sequence(env: Env, emitter: Address) -> u64;
 
-    /// Get the hash of a posted message by emitter and sequence number.
-    ///
-    /// # Arguments
-    /// * `emitter` - Emitter address
-    /// * `sequence` - Message sequence number
-    ///
-    /// # Returns
-    /// Message hash, or None if not found
-    fn get_posted_message_hash(env: Env, emitter: Address, sequence: u64) -> Option<BytesN<32>>;
-
     /// Get the current message fee in stroops (10^-7 XLM).
     ///
     /// # Returns

--- a/stellar/integration-tests/tests/localnet_message_fee.rs
+++ b/stellar/integration-tests/tests/localnet_message_fee.rs
@@ -154,17 +154,7 @@ fn integration_set_message_fee_and_required_fee() {
     );
 
     println!("Verifying balance changes...");
-    let contract_balance = ctx.invoke(
-        &ctx.admin_identity,
-        &contract_id,
-        "get_contract_balance",
-        &[],
-    );
-    let contract_balance = contract_balance
-        .trim()
-        .trim_matches('"')
-        .parse::<i128>()
-        .expect("Failed to parse contract balance");
+    let contract_balance = ctx.get_balance(&native_token, &contract_id);
     assert!(
         contract_balance >= new_fee as i128,
         "Contract balance should have increased"

--- a/stellar/integration-tests/tests/localnet_post_message.rs
+++ b/stellar/integration-tests/tests/localnet_post_message.rs
@@ -52,18 +52,6 @@ fn integration_post_message_no_fee_flow() {
         .expect("Failed to parse next sequence");
     assert_eq!(next_sequence, 1, "Next sequence should be 1");
 
-    let hash_out = ctx.invoke(
-        &ctx.admin_identity,
-        &contract_id,
-        "get_posted_message_hash",
-        &["--emitter", &emitter_addr, "--sequence", "0"],
-    );
-    assert!(
-        !hash_out.trim().is_empty() && hash_out.trim() != "void",
-        "Message hash should not be empty"
-    );
-    println!("Message hash: {}", hash_out.trim());
-
     // Fetch events via RPC
     let found_event = find_event(
         &ctx.rpc_url,

--- a/stellar/integration-tests/tests/localnet_transfer_fees.rs
+++ b/stellar/integration-tests/tests/localnet_transfer_fees.rs
@@ -43,17 +43,7 @@ fn integration_transfer_fees_flow() {
         ],
     );
 
-    let contract_balance = ctx.invoke(
-        &ctx.admin_identity,
-        &contract_id,
-        "get_contract_balance",
-        &[],
-    );
-    let contract_balance = contract_balance
-        .trim()
-        .trim_matches('"')
-        .parse::<i128>()
-        .expect("Failed to parse contract balance");
+    let contract_balance = ctx.get_balance(&native_token, &contract_id);
     assert!(contract_balance >= fund_amount, "Contract should be funded");
     println!("Contract balance: {} stroops", contract_balance);
 
@@ -100,17 +90,7 @@ fn integration_transfer_fees_flow() {
     );
 
     println!("Verifying balance changes...");
-    let new_contract_balance = ctx.invoke(
-        &ctx.admin_identity,
-        &contract_id,
-        "get_contract_balance",
-        &[],
-    );
-    let new_contract_balance = new_contract_balance
-        .trim()
-        .trim_matches('"')
-        .parse::<i128>()
-        .expect("Failed to parse new contract balance");
+    let new_contract_balance = ctx.get_balance(&native_token, &contract_id);
     assert_eq!(
         new_contract_balance,
         contract_balance - transfer_amount as i128,

--- a/stellar/integration-tests/tests/localnet_transfer_fees.rs
+++ b/stellar/integration-tests/tests/localnet_transfer_fees.rs
@@ -125,18 +125,6 @@ fn integration_transfer_fees_flow() {
     );
     println!("Balances verified successfully.");
 
-    // Verify get_last_fee_transfer and event
-    let last_transfer_out = ctx.invoke(
-        &ctx.admin_identity,
-        &contract_id,
-        "get_last_fee_transfer",
-        &[],
-    );
-    assert!(
-        !last_transfer_out.contains("void") && !last_transfer_out.trim().is_empty(),
-        "Last fee transfer should have a timestamp"
-    );
-
     println!("Verifying event via RPC...");
     let found_event = find_event(
         &ctx.rpc_url,


### PR DESCRIPTION
## Summary

Removes three Stellar-only convenience getters with no equivalent in EVM or Solana.

- **`get_posted_message_hash`** — Remove getter, storage writes (set + extend_ttl per message), and `PostedMessage` storage key. Guardians observe events, not storage.
- **`get_last_fee_transfer`** — Remove getter, storage writes, and `LastFeeTransfer` storage key. `FeeTransferEvent` already provides the audit trail.
- **`get_contract_balance`** — Remove getter. Native token balance is queryable via RPC without a contract invocation.