### PR TITLE
Feat/lookup table

### DIFF
--- a/stellar/contracts/wormhole-contract/src/governance/set_message_fee.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/set_message_fee.rs
@@ -119,7 +119,9 @@ mod tests {
     use super::*;
     use crate::Wormhole;
     use soroban_sdk::{Bytes, BytesN, IntoVal, Symbol, testutils::Events, vec};
-    use wormhole_soroban_client::{CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, MODULE_CORE};
+    use wormhole_soroban_client::{
+        CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, MODULE_CORE,
+    };
 
     fn build_payload(env: &Env, module: [u8; 32], action: u8, chain: u16, fee: u64) -> Bytes {
         let mut payload = Bytes::new(env);

--- a/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
@@ -132,7 +132,9 @@ mod tests {
         contracttype,
         testutils::{Address as TestAddress, Events, Ledger},
     };
-    use wormhole_soroban_client::{CHAIN_ID_STELLAR, GOVERNANCE_EMITTER, MODULE_CORE, NATIVE_TOKEN_ADDRESS};
+    use wormhole_soroban_client::{
+        CHAIN_ID_STELLAR, GOVERNANCE_EMITTER, MODULE_CORE, NATIVE_TOKEN_ADDRESS,
+    };
 
     #[contracttype]
     #[derive(Clone)]

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -21,9 +21,11 @@ use crate::governance::{
     guardian_set::{get_current_guardian_set_index, get_guardian_set, get_guardian_set_expiry},
 };
 use soroban_sdk::{Address, Bytes, BytesN, Env, Vec, contract, contractimpl};
+use storage::StorageKey;
 use wormhole_soroban_client::{
     CHAIN_ID_STELLAR, ConsistencyLevel, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, GuardianSetInfo,
-    WormholeCoreInterface, WormholeError,
+    STORAGE_TTL_EXTENSION, STORAGE_TTL_THRESHOLD, WormholeCoreInterface, WormholeError,
+    hash_address,
 };
 
 mod governance;
@@ -150,12 +152,35 @@ impl WormholeCoreInterface for Wormhole {
     fn get_governance_emitter(env: Env) -> BytesN<32> {
         BytesN::from_array(&env, &GOVERNANCE_EMITTER)
     }
+
+    fn record_address(env: Env, address: Address) -> Result<BytesN<32>, WormholeError> {
+        let hash = hash_address(&env, &address);
+        let key = StorageKey::AddressTable(hash.clone());
+        env.storage().persistent().set(&key, &address);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTENSION);
+        Ok(hash)
+    }
+
+    fn get_address_from_hash(env: Env, hash: BytesN<32>) -> Result<Address, WormholeError> {
+        let key = StorageKey::AddressTable(hash);
+        let Some(address) = env.storage().persistent().get(&key) else {
+            return Err(WormholeError::AddressNotFound);
+        };
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTENSION);
+
+        Ok(address)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{Bytes, BytesN, Env, vec};
+    use soroban_sdk::{Bytes, BytesN, Env, testutils::Address as _, vec};
     use wormhole_soroban_client::{
         ACTION_GUARDIAN_SET_UPGRADE, ACTION_SET_MESSAGE_FEE, ACTION_TRANSFER_FEES,
         GOVERNANCE_EMITTER, MODULE_CORE,
@@ -203,6 +228,41 @@ mod tests {
         let (_contract_id, client) = deploy_initialized(&env);
         assert_eq!(client.get_chain_id(), u32::from(CHAIN_ID_STELLAR));
         assert_eq!(client.get_governance_chain_id(), GOVERNANCE_CHAIN_ID);
+    }
+
+    #[test]
+    fn test_record_address_round_trip() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let address = Address::generate(&env);
+        let hash = hash_address(&env, &address);
+
+        assert_eq!(client.record_address(&address), hash);
+        assert_eq!(client.get_address_from_hash(&hash), address);
+    }
+
+    #[test]
+    fn test_record_account_address_round_trip() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let pk_bytes = BytesN::from_array(&env, &[7u8; 32]);
+        let address = crate::utils::address_from_ed25519_pk_bytes(&env, &pk_bytes);
+        let hash = hash_address(&env, &address);
+
+        assert_eq!(client.record_address(&address), hash);
+        assert_eq!(client.get_address_from_hash(&hash), address);
+    }
+
+    #[test]
+    fn test_get_address_from_hash_returns_not_found_for_missing_hash() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let hash = BytesN::<32>::from_array(&env, &[9u8; 32]);
+
+        assert_eq!(
+            client.try_get_address_from_hash(&hash),
+            Err(Ok(WormholeError::AddressNotFound))
+        );
     }
 
     #[test]

--- a/stellar/contracts/wormhole-contract/src/message.rs
+++ b/stellar/contracts/wormhole-contract/src/message.rs
@@ -341,5 +341,4 @@ mod tests {
         assert_eq!(s2, 2);
         assert_eq!(client.get_emitter_sequence(&emitter), 3);
     }
-
 }

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -26,4 +26,6 @@ pub enum StorageKey {
     MessageFee,
     /// Next sequence number for each emitter address.
     EmitterSequence(Address),
+    /// Hash of an address used in `from/to` fields.
+    AddressTable(BytesN<32>),
 }

--- a/stellar/contracts/wormhole-soroban-client/src/error.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/error.rs
@@ -65,6 +65,8 @@ pub enum WormholeError {
     GuardianSetNotFound = 41,
     /// Cannot overwrite an existing guardian set.
     GuardianSetAlreadyExists = 42,
+    /// Requested address hash does not exist in storage.
+    AddressNotFound = 43,
 
     // ========== Fee Errors (50-59) ==========
     /// Emitter has not approved sufficient fee for message posting.

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -44,6 +44,15 @@ pub use types::*;
 
 use soroban_sdk::{Address, Bytes, BytesN, Env, String, contractclient};
 
+/// Computes the canonical Wormhole lookup hash for a Soroban address.
+///
+/// The hash input is the address StrKey string bytes.
+pub fn hash_address(env: &Env, address: &Address) -> BytesN<32> {
+    env.crypto()
+        .keccak256(&address.to_string().to_bytes())
+        .to_bytes()
+}
+
 /// Complete public interface for the Wormhole Core contract.
 ///
 /// Defines all contract entry points for VAA verification, governance actions,
@@ -271,6 +280,32 @@ pub trait WormholeCoreInterface {
     /// # Returns
     /// 32-byte governance emitter address
     fn get_governance_emitter(env: Env) -> BytesN<32>;
+
+    /// Record a Soroban address in the hash lookup table.
+    ///
+    /// Returns the canonical hash used as the lookup key.
+    fn record_address(env: Env, address: Address) -> Result<BytesN<32>, WormholeError>;
+
+    /// Resolve a previously recorded address hash.
+    fn get_address_from_hash(env: Env, hash: BytesN<32>) -> Result<Address, WormholeError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as TestAddress};
+
+    #[test]
+    fn test_hash_address_uses_strkey_string_bytes() {
+        let env = Env::default();
+        let address = Address::generate(&env);
+        let expected = env
+            .crypto()
+            .keccak256(&address.to_string().to_bytes())
+            .to_bytes();
+
+        assert_eq!(hash_address(&env, &address), expected);
+    }
 }
 
 /// Public interface for the Wormhole Executor contract.

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -293,7 +293,7 @@ pub trait WormholeCoreInterface {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as TestAddress};
+    use soroban_sdk::testutils::Address as _;
 
     #[test]
     fn test_hash_address_uses_strkey_string_bytes() {

--- a/stellar/integration-tests/src/lib.rs
+++ b/stellar/integration-tests/src/lib.rs
@@ -110,13 +110,7 @@ impl TestContext {
     }
 
     pub fn fund_identity(&self, name: &str) {
-        run(Command::new("stellar").args([
-            "keys",
-            "fund",
-            "--network",
-            &self.network,
-            name,
-        ]));
+        run(Command::new("stellar").args(["keys", "fund", "--network", &self.network, name]));
     }
 
     pub fn get_identity_address(&self, name: &str) -> String {
@@ -127,13 +121,7 @@ impl TestContext {
 
     pub fn setup_identity(&self, name: &str) -> String {
         let _ = Command::new("stellar").args(["keys", "rm", name]).output();
-        run(Command::new("stellar").args([
-            "keys",
-            "generate",
-            "--network",
-            &self.network,
-            name,
-        ]));
+        run(Command::new("stellar").args(["keys", "generate", "--network", &self.network, name]));
         let addr = run(Command::new("stellar").args(["keys", "address", name]))
             .trim()
             .to_string();


### PR DESCRIPTION
## Summary

Add to the core contract the methods for recording Soroban addresses under a canonical hash and resolving those hashes back to addresses. 

## Changes

- Add `hash_address` helper using the address StrKey string bytes as the hash input.
- Add `record_address` and `get_address_from_hash` to the Wormhole Core interface.
- Store address lookups under `StorageKey::AddressTable`.
- Extend storage TTL on address lookup writes and reads.
- Add `AddressNotFound` for missing lookup entries.
- Add unit tests for address lookup round trips and missing hash behavior.

## Breaking changes

None.

## Notes

The address hash intentionally uses the Soroban address StrKey string bytes, not raw account or contract bytes. 

