### PR TITLE
Stellar lookup table

### DIFF
--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -21,11 +21,9 @@ use crate::governance::{
     guardian_set::{get_current_guardian_set_index, get_guardian_set, get_guardian_set_expiry},
 };
 use soroban_sdk::{Address, Bytes, BytesN, Env, Vec, contract, contractimpl};
-use storage::StorageKey;
 use wormhole_soroban_client::{
     CHAIN_ID_STELLAR, ConsistencyLevel, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, GuardianSetInfo,
-    STORAGE_TTL_EXTENSION, STORAGE_TTL_THRESHOLD, WormholeCoreInterface, WormholeError,
-    hash_address,
+    WormholeCoreInterface, WormholeError,
 };
 
 mod governance;
@@ -152,35 +150,12 @@ impl WormholeCoreInterface for Wormhole {
     fn get_governance_emitter(env: Env) -> BytesN<32> {
         BytesN::from_array(&env, &GOVERNANCE_EMITTER)
     }
-
-    fn record_address(env: Env, address: Address) -> Result<BytesN<32>, WormholeError> {
-        let hash = hash_address(&env, &address);
-        let key = StorageKey::AddressTable(hash.clone());
-        env.storage().persistent().set(&key, &address);
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTENSION);
-        Ok(hash)
-    }
-
-    fn get_address_from_hash(env: Env, hash: BytesN<32>) -> Result<Address, WormholeError> {
-        let key = StorageKey::AddressTable(hash);
-        let Some(address) = env.storage().persistent().get(&key) else {
-            return Err(WormholeError::AddressNotFound);
-        };
-
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTENSION);
-
-        Ok(address)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{Bytes, BytesN, Env, testutils::Address as _, vec};
+    use soroban_sdk::{Bytes, BytesN, Env, vec};
     use wormhole_soroban_client::{
         ACTION_GUARDIAN_SET_UPGRADE, ACTION_SET_MESSAGE_FEE, ACTION_TRANSFER_FEES,
         GOVERNANCE_EMITTER, MODULE_CORE,
@@ -228,41 +203,6 @@ mod tests {
         let (_contract_id, client) = deploy_initialized(&env);
         assert_eq!(client.get_chain_id(), u32::from(CHAIN_ID_STELLAR));
         assert_eq!(client.get_governance_chain_id(), GOVERNANCE_CHAIN_ID);
-    }
-
-    #[test]
-    fn test_record_address_round_trip() {
-        let env = Env::default();
-        let (_contract_id, client) = deploy_initialized(&env);
-        let address = Address::generate(&env);
-        let hash = hash_address(&env, &address);
-
-        assert_eq!(client.record_address(&address), hash);
-        assert_eq!(client.get_address_from_hash(&hash), address);
-    }
-
-    #[test]
-    fn test_record_account_address_round_trip() {
-        let env = Env::default();
-        let (_contract_id, client) = deploy_initialized(&env);
-        let pk_bytes = BytesN::from_array(&env, &[7u8; 32]);
-        let address = crate::utils::address_from_ed25519_pk_bytes(&env, &pk_bytes);
-        let hash = hash_address(&env, &address);
-
-        assert_eq!(client.record_address(&address), hash);
-        assert_eq!(client.get_address_from_hash(&hash), address);
-    }
-
-    #[test]
-    fn test_get_address_from_hash_returns_not_found_for_missing_hash() {
-        let env = Env::default();
-        let (_contract_id, client) = deploy_initialized(&env);
-        let hash = BytesN::<32>::from_array(&env, &[9u8; 32]);
-
-        assert_eq!(
-            client.try_get_address_from_hash(&hash),
-            Err(Ok(WormholeError::AddressNotFound))
-        );
     }
 
     #[test]

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -26,6 +26,4 @@ pub enum StorageKey {
     MessageFee,
     /// Next sequence number for each emitter address.
     EmitterSequence(Address),
-    /// Hash of an address used in `from/to` fields.
-    AddressTable(BytesN<32>),
 }

--- a/stellar/contracts/wormhole-soroban-client/src/error.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/error.rs
@@ -63,8 +63,6 @@ pub enum WormholeError {
     GuardianSetNotFound = 41,
     /// Cannot overwrite an existing guardian set.
     GuardianSetAlreadyExists = 42,
-    /// Requested address hash does not exist in storage.
-    AddressNotFound = 43,
 
     // ========== Fee Errors (50-59) ==========
     /// Emitter has not approved sufficient fee for message posting.

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -275,14 +275,6 @@ pub trait WormholeCoreInterface {
     /// # Returns
     /// 32-byte governance emitter address
     fn get_governance_emitter(env: Env) -> BytesN<32>;
-
-    /// Record a Soroban address in the hash lookup table.
-    ///
-    /// Returns the canonical hash used as the lookup key.
-    fn record_address(env: Env, address: Address) -> Result<BytesN<32>, WormholeError>;
-
-    /// Resolve a previously recorded address hash.
-    fn get_address_from_hash(env: Env, hash: BytesN<32>) -> Result<Address, WormholeError>;
 }
 
 #[cfg(test)]

--- a/stellar/contracts/wormhole-soroban-client/src/lib.rs
+++ b/stellar/contracts/wormhole-soroban-client/src/lib.rs
@@ -39,9 +39,18 @@ pub use types::*;
 
 use soroban_sdk::{Address, Bytes, BytesN, Env, contractclient};
 
-/// Computes the canonical Wormhole lookup hash for a Soroban address.
+/// Computes the canonical 32-byte Wormhole identity of a Soroban address.
 ///
-/// The hash input is the address StrKey string bytes.
+/// This is the canonical mapping from a Stellar `Address` (account `G…` or
+/// contract `C…`) onto Wormhole's fixed 32-byte wire format, shared by the core
+/// contract, NTT, and the off-chain SDK. Any reimplementation must produce
+/// identical bytes; the test vectors in this crate pin the exact mapping.
+///
+/// Definition: `keccak256` over the **StrKey text** — `address.to_string()`
+/// returns the canonical `G…`/`C…` string, and `.to_bytes()` is its raw ASCII
+/// with no length prefix and no trailing NUL. Hashing the StrKey (which carries
+/// the kind prefix + checksum) keeps accounts and contracts collision-free even
+/// when their underlying 32 bytes coincide.
 pub fn hash_address(env: &Env, address: &Address) -> BytesN<32> {
     env.crypto()
         .keccak256(&address.to_string().to_bytes())
@@ -280,7 +289,7 @@ pub trait WormholeCoreInterface {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{String, testutils::Address as _};
 
     #[test]
     fn test_hash_address_uses_strkey_string_bytes() {
@@ -292,5 +301,47 @@ mod tests {
             .to_bytes();
 
         assert_eq!(hash_address(&env, &address), expected);
+    }
+
+    fn assert_hash(strkey: &str, expected: [u8; 32]) {
+        let env = Env::default();
+        let address = Address::from_string(&String::from_str(&env, strkey));
+
+        // The hash input is the raw StrKey ASCII: no length prefix, no trailing NUL.
+        assert_eq!(
+            address.to_string().to_bytes(),
+            Bytes::from_slice(&env, strkey.as_bytes())
+        );
+        assert_eq!(
+            hash_address(&env, &address),
+            BytesN::from_array(&env, &expected)
+        );
+    }
+
+    // Fixed vectors pinning hash_address for an account and a contract StrKey.
+    // Expected values are keccak256 over the StrKey ASCII, computed independently;
+    // NTT and the off-chain SDK must produce identical bytes.
+    #[test]
+    fn test_hash_address_account_vector() {
+        assert_hash(
+            "GAIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCF6M",
+            [
+                0x27, 0x99, 0x72, 0xbd, 0x86, 0xb0, 0xe9, 0xcf, 0xf5, 0x3e, 0xd0, 0x68, 0xcc,
+                0x08, 0x9b, 0x96, 0x59, 0x64, 0x75, 0x48, 0x6a, 0x38, 0x2e, 0xe5, 0x62, 0x95,
+                0x76, 0xb3, 0x64, 0x12, 0x5d, 0x27,
+            ],
+        );
+    }
+
+    #[test]
+    fn test_hash_address_contract_vector() {
+        assert_hash(
+            "CARCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEVQO",
+            [
+                0x79, 0xa0, 0x39, 0x9c, 0x82, 0x8a, 0xeb, 0x24, 0xb7, 0xf1, 0x70, 0x05, 0xd1,
+                0x29, 0xf4, 0xa2, 0x95, 0xb3, 0xa6, 0x68, 0x68, 0x74, 0xcb, 0x1b, 0xea, 0xe5,
+                0xc9, 0xc9, 0x5b, 0x95, 0xa9, 0x44,
+            ],
+        );
     }
 }


### PR DESCRIPTION
Corrects the Stellar core contract's handling of the address lookup scheme.

PR #76 added a `hash → Address` storage registry (`record_address` /
`get_address_from_hash` + an `AddressTable` storage key) to the core contract.
The core contract has no `from`/`to` fields and never reconstructs an address
from the wire, so that registry was orphaned — wired to nothing. This removes it
and keeps only the piece the core actually owns: the canonical `hash_address`
primitive.

The storage registry belongs in the NTT manager (the only place that resolves a
32-byte wire value back into a real `Address` — the inbound recipient). It is
implemented there in a separate NTT PR. `hash_address` stays a pure function in
the shared `wormhole-soroban-client` crate so the core contract, NTT, and the
off-chain SDK all compute the identical 32-byte identity.