### PR TITLE
fix: gofmt stellar watcher

### DIFF
--- a/node/pkg/watchers/stellar/watcher.go
+++ b/node/pkg/watchers/stellar/watcher.go
@@ -173,11 +173,8 @@ func (w *watcher) Run(ctx context.Context) error {
 	w.logger = logger
 
 	if w.nextLedger == 0 {
-		seq, err := w.getLatestLedger(ctx)
+		seq, err := w.getInitialLedger(ctx, logger)
 		if err != nil {
-			stellarConnectionErrors.WithLabelValues(w.networkName, "initial_ledger").Inc()
-			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
-			logger.Error("failed to get latest ledger", zap.Error(err))
 			return err
 		}
 		w.nextLedger = seq
@@ -209,6 +206,42 @@ func (w *watcher) Run(ctx context.Context) error {
 				stellarConnectionErrors.WithLabelValues(w.networkName, "poll").Inc()
 				p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
 				logger.Warn("pollOnce error", zap.Error(err))
+			}
+		}
+	}
+}
+
+// getInitialLedger fetches the starting ledger, retrying with capped exponential
+// backoff. A transient RPC outage at startup (e.g. the Soroban RPC not yet
+// reachable when the guardian boots) must not kill the watcher, mirroring the
+// resilience of the poll loop. Returns an error only when the context is cancelled.
+func (w *watcher) getInitialLedger(ctx context.Context, logger *zap.Logger) (uint64, error) {
+	backoff := w.pollInterval
+	if backoff <= 0 {
+		backoff = 700 * time.Millisecond
+	}
+	const maxBackoff = 60 * time.Second
+
+	for {
+		seq, err := w.getLatestLedger(ctx)
+		if err == nil {
+			return seq, nil
+		}
+
+		stellarConnectionErrors.WithLabelValues(w.networkName, "initial_ledger").Inc()
+		p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
+		logger.Warn("failed to get latest ledger, retrying", zap.Error(err), zap.Duration("backoff", backoff))
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
 			}
 		}
 	}

--- a/node/pkg/watchers/stellar/watcher.go
+++ b/node/pkg/watchers/stellar/watcher.go
@@ -62,7 +62,7 @@ type WatcherConfig struct {
 	PollInterval time.Duration
 	ReadTimeout  time.Duration
 	StartLedger  uint64
-	MaxPerPoll int
+	MaxPerPoll   int
 }
 
 func (wc *WatcherConfig) Create(

--- a/node/pkg/watchers/stellar/watcher_test.go
+++ b/node/pkg/watchers/stellar/watcher_test.go
@@ -239,8 +239,8 @@ func (m *mockSorobanRPC) methodCount(method string) int {
 // ---------------------------------------------------------------------------
 
 const (
-	testContract  = "CBWQUIB4R65Z2DGC263FQ7BBI7TGIGOLFTYMLE6QPWBD5QDOUVJY3AKR"
-	testNetworkID = "stellar-test"
+	testContract    = "CBWQUIB4R65Z2DGC263FQ7BBI7TGIGOLFTYMLE6QPWBD5QDOUVJY3AKR"
+	testNetworkID   = "stellar-test"
 	testStartLedger = uint64(100)
 )
 
@@ -562,8 +562,8 @@ func TestReobserve_UsesCustomEndpoint(t *testing.T) {
 	txHash := "dead000000000000000000000000000000000000000000000000000000000000"
 	createdAt := int64(1700000000)
 
-	primaryMock := newMockRPC(100)  // primary server: no transactions
-	customMock := newMockRPC(300)   // custom server: has the transaction
+	primaryMock := newMockRPC(100) // primary server: no transactions
+	customMock := newMockRPC(300)  // custom server: has the transaction
 	customMock.transactions[txHash] = mockTx{status: "SUCCESS", ledger: 200, createdAt: createdAt}
 	customMock.events = []mockEvent{
 		{


### PR DESCRIPTION
Apply goimports formatting to satisfy the format lint check.