### PR TITLE
stellar: add core Soroban contract

### DIFF
--- a/stellar/Cargo.lock
+++ b/stellar/Cargo.lock
@@ -158,8 +158,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "autocfg"
@@ -184,6 +190,22 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed83caece3afc59919481b33b472e1432d1abc4641ed9100be142ef5110b406"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
 
 [[package]]
 name = "block-buffer"
@@ -296,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -542,7 +564,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -567,7 +589,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -597,7 +619,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -644,13 +666,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -707,6 +741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -996,14 +1039,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1013,7 +1072,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1022,7 +1091,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1116,6 +1194,26 @@ dependencies = [
  "generic-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1234,7 +1332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1300,7 +1398,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.16",
  "hex-literal",
  "hmac",
  "k256",
@@ -1308,8 +1406,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1362,7 +1460,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1624,6 +1722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +1883,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wormhole-contract"
+version = "0.1.0"
+dependencies = [
+ "secp256k1",
+ "soroban-sdk",
+ "wormhole-soroban-client",
 ]
 
 [[package]]

--- a/stellar/Cargo.toml
+++ b/stellar/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 resolver = "3"
 members = [
-  "contracts/wormhole-soroban-client"
+  "contracts/wormhole-soroban-client",
+  "contracts/wormhole-contract"
 ]
 
 [workspace.package]

--- a/stellar/contracts/wormhole-contract/Cargo.toml
+++ b/stellar/contracts/wormhole-contract/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "wormhole-contract"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc", "hazmat-address"] }
+wormhole-soroban-client = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+secp256k1 = { version = "0.31.1", features = ["recovery"] }

--- a/stellar/contracts/wormhole-contract/src/governance/action.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/action.rs
@@ -1,0 +1,501 @@
+//! Common governance action trait and processing utilities.
+//!
+//! Defines the [`GovernanceAction`] trait that all governance actions
+//! implement, providing a standard flow: verify VAA → check replay → parse
+//! payload → validate → consume → execute.
+
+use crate::{storage::StorageKey, utils::keccak256_hash, vaa::verify_vaa_signatures};
+use core::convert::TryFrom;
+use soroban_sdk::{Bytes, BytesN, Env};
+use wormhole_soroban_client::{
+    BytesReader, CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, MODULE_CORE, VAA,
+    WormholeError,
+};
+
+/// Trait for implementing Wormhole governance actions.
+///
+/// Each action defines a `Payload` type with parsing via `TryFrom`, validation
+/// logic, and execution behavior. The `submit` method provides the standard
+/// governance flow with replay protection.
+///
+/// **Critical**: VAA consumption happens BEFORE execution to prevent replay
+/// if the execution modifies contract behavior (e.g., contract upgrades).
+pub trait GovernanceAction {
+    /// Payload type for this action, parsed from VAA payload bytes.
+    type Payload: for<'a> TryFrom<(&'a Env, &'a Bytes), Error = WormholeError>;
+
+    /// Validates the parsed payload (e.g., sequential guardian set index).
+    fn validate_payload(env: &Env, payload: &Self::Payload) -> Result<(), WormholeError>;
+
+    /// Executes the governance action after all validation passes.
+    fn execute(env: &Env, vaa: &VAA, payload: &Self::Payload) -> Result<(), WormholeError>;
+
+    /// Standard governance submission flow with replay protection.
+    ///
+    /// 1. Parse and verify VAA (signatures + governance source)
+    /// 2. Check VAA not already consumed
+    /// 3. Parse and validate payload
+    /// 4. **Consume VAA (before execution!)**
+    /// 5. Execute the action
+    fn submit(env: &Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
+        let (vaa, vaa_hash) = verify_and_hash_governance_vaa(env, &vaa_bytes)?;
+        require_vaa_not_consumed(env, &vaa_hash)?;
+
+        let payload = Self::Payload::try_from((env, &vaa.payload))?;
+        Self::validate_payload(env, &payload)?;
+
+        consume_vaa(env, &vaa_hash);
+
+        Self::execute(env, &vaa, &payload)?;
+
+        Ok(())
+    }
+}
+
+/// Validates that a VAA originates from the authorized governance source.
+fn verify_governance_vaa(vaa: &VAA) -> Result<(), WormholeError> {
+    if vaa.emitter_chain != GOVERNANCE_CHAIN_ID {
+        return Err(WormholeError::InvalidGovernanceChain);
+    }
+
+    if vaa.emitter_address.to_array() != GOVERNANCE_EMITTER {
+        return Err(WormholeError::InvalidGovernanceEmitter);
+    }
+
+    Ok(())
+}
+
+/// Parses, verifies, and hashes a governance VAA for consumption tracking.
+fn verify_and_hash_governance_vaa(
+    env: &Env,
+    vaa_bytes: &Bytes,
+) -> Result<(VAA, BytesN<32>), WormholeError> {
+    let vaa = VAA::try_from((env, vaa_bytes))?;
+    verify_governance_vaa(&vaa)?;
+    verify_vaa_signatures(&vaa, env)?;
+
+    let body_bytes = vaa.serialize_body(env);
+    let vaa_hash = keccak256_hash(env, &body_bytes);
+
+    Ok((vaa, vaa_hash))
+}
+
+/// Checks if a VAA body hash has been consumed.
+fn is_vaa_consumed(env: &Env, hash: &BytesN<32>) -> bool {
+    env.storage()
+        .persistent()
+        .has(&StorageKey::ConsumedGovernanceVAA(hash.clone()))
+}
+
+/// Returns error if VAA has already been consumed (replay protection).
+fn require_vaa_not_consumed(env: &Env, hash: &BytesN<32>) -> Result<(), WormholeError> {
+    if is_vaa_consumed(env, hash) {
+        return Err(WormholeError::GovernanceVAAAlreadyConsumed);
+    }
+    Ok(())
+}
+
+/// Marks a VAA as consumed to prevent replay attacks.
+///
+/// Uses persistent storage, which is archived (not deleted) on TTL expiry.
+/// An attacker replaying a VAA whose entry was archived must first restore
+/// it via `RestoreFootprint`, at which point the consumed flag blocks replay.
+fn consume_vaa(env: &Env, hash: &BytesN<32>) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::ConsumedGovernanceVAA(hash.clone()), &true);
+}
+
+/// Checks if a governance VAA has been consumed without full verification.
+pub fn is_governance_vaa_consumed_from_bytes(
+    env: &Env,
+    vaa_bytes: &Bytes,
+) -> Result<bool, WormholeError> {
+    let body_bytes = VAA::get_body_bytes(vaa_bytes)?;
+    let vaa_hash = keccak256_hash(env, &body_bytes);
+    Ok(is_vaa_consumed(env, &vaa_hash))
+}
+
+/// Parses the 35-byte governance header: module (32) + action (1) + chain (2).
+pub fn parse_governance_header(
+    env: &Env,
+    reader: &mut BytesReader,
+) -> Result<(BytesN<32>, u8, u16), WormholeError> {
+    let module = reader.read_bytes_n::<32>()?;
+    let action = reader.read_u8()?;
+    let chain = reader.read_u16_be()?;
+
+    Ok((BytesN::from_array(env, &module.to_array()), action, chain))
+}
+
+/// Validates governance header fields against expected values.
+///
+/// - Module must be "Core" (right-padded)
+/// - Action must match the expected action ID
+/// - Chain must be 0 (all chains) or 61 (Stellar)
+pub fn validate_governance_header(
+    module: &BytesN<32>,
+    action: u8,
+    chain: u16,
+    expected_action: u8,
+) -> Result<(), WormholeError> {
+    if module.to_array() != MODULE_CORE {
+        return Err(WormholeError::InvalidGovernanceModule);
+    }
+
+    if action != expected_action {
+        return Err(WormholeError::InvalidGovernanceAction);
+    }
+
+    if chain != 0 && chain != CHAIN_ID_STELLAR {
+        return Err(WormholeError::InvalidGovernanceChain);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        Wormhole,
+        governance::{
+            GuardianSetUpgradeAction, SetMessageFeeAction, get_message_fee,
+            guardian_set::get_current_guardian_set_index,
+        },
+    };
+    use soroban_sdk::{
+        Bytes, BytesN, Env, IntoVal, Symbol, Vec,
+        testutils::{Events, Ledger},
+        vec,
+    };
+    use wormhole_soroban_client::{
+        ACTION_GUARDIAN_SET_UPGRADE, ACTION_SET_MESSAGE_FEE, ConsistencyLevel, GOVERNANCE_CHAIN_ID,
+        GOVERNANCE_EMITTER, MODULE_CORE, SET_MESSAGE_FEE_PAYLOAD_MIN_LENGTH, Signature, VAA,
+    };
+
+    fn deploy_with_guardian(env: &Env, guardian_eth: BytesN<20>) -> soroban_sdk::Address {
+        let initial_guardians = vec![env, guardian_eth];
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
+        env.register(Wormhole, (initial_guardians, governance_emitter))
+    }
+
+    fn serialize_vaa(env: &Env, vaa: &VAA) -> Bytes {
+        let mut out = Bytes::new(env);
+        out.push_back(vaa.version as u8);
+        out.append(&Bytes::from_slice(
+            env,
+            &vaa.guardian_set_index.to_be_bytes(),
+        ));
+        out.push_back(vaa.signatures.len() as u8);
+
+        for sig in vaa.signatures.iter() {
+            out.push_back(sig.guardian_index as u8);
+            out.append(&Bytes::from_array(env, &sig.r.to_array()));
+            out.append(&Bytes::from_array(env, &sig.s.to_array()));
+            out.push_back(sig.v as u8);
+        }
+
+        out.append(&Bytes::from_slice(env, &vaa.timestamp.to_be_bytes()));
+        out.append(&Bytes::from_slice(env, &vaa.nonce.to_be_bytes()));
+        out.append(&Bytes::from_slice(
+            env,
+            &(vaa.emitter_chain as u16).to_be_bytes(),
+        ));
+        out.append(&Bytes::from_array(env, &vaa.emitter_address.to_array()));
+        out.append(&Bytes::from_slice(env, &vaa.sequence.to_be_bytes()));
+        out.push_back(vaa.consistency_level as u8);
+        out.append(&vaa.payload);
+        out
+    }
+
+    fn build_set_fee_payload(env: &Env, action: u8, chain: u16, fee: u64) -> Bytes {
+        let mut payload = Bytes::new(env);
+        payload.append(&Bytes::from_array(env, &MODULE_CORE));
+        payload.push_back(action);
+        payload.append(&Bytes::from_slice(env, &chain.to_be_bytes()));
+        payload.append(&Bytes::from_array(env, &[0u8; 24]));
+        payload.append(&Bytes::from_slice(env, &fee.to_be_bytes()));
+        payload
+    }
+
+    fn build_guardian_upgrade_payload(
+        env: &Env,
+        action: u8,
+        chain: u16,
+        new_index: u32,
+        key: BytesN<20>,
+    ) -> Bytes {
+        let mut payload = Bytes::new(env);
+        payload.append(&Bytes::from_array(env, &MODULE_CORE));
+        payload.push_back(action);
+        payload.append(&Bytes::from_slice(env, &chain.to_be_bytes()));
+        payload.append(&Bytes::from_slice(env, &new_index.to_be_bytes()));
+        payload.push_back(1);
+        payload.append(&Bytes::from_array(env, &key.to_array()));
+        payload
+    }
+
+    fn sign_vaa_with_key(env: &Env, mut vaa: VAA, sk_bytes: [u8; 32]) -> (VAA, BytesN<20>) {
+        let body = vaa.serialize_body(env);
+        let body_hash: Bytes = crate::utils::keccak256_hash(env, &body).into();
+        let double_hash = env.crypto().keccak256(&body_hash).to_array();
+
+        let secp = secp256k1::Secp256k1::new();
+        let sk = secp256k1::SecretKey::from_byte_array(sk_bytes).unwrap();
+        let pk = secp256k1::PublicKey::from_secret_key(&secp, &sk);
+        let pk_bytes65 = BytesN::<65>::from_array(env, &pk.serialize_uncompressed());
+        let guardian_eth = crate::utils::pubkey_to_eth_address(env, &pk_bytes65);
+
+        let message = secp256k1::Message::from_digest(double_hash);
+        let sig = secp.sign_ecdsa_recoverable(message, &sk);
+        let (recid, compact64) = sig.serialize_compact();
+
+        let mut r = [0u8; 32];
+        let mut s = [0u8; 32];
+        r.copy_from_slice(&compact64[0..32]);
+        s.copy_from_slice(&compact64[32..64]);
+
+        let mut sigs = Vec::new(env);
+        sigs.push_back(Signature {
+            guardian_index: 0,
+            r: BytesN::from_array(env, &r),
+            s: BytesN::from_array(env, &s),
+            v: i32::from(recid) as u32,
+        });
+        vaa.signatures = sigs;
+        (vaa, guardian_eth)
+    }
+
+    fn build_signed_set_fee_vaa(
+        env: &Env,
+        emitter_chain: u32,
+        emitter_address: [u8; 32],
+        fee: u64,
+    ) -> (Bytes, BytesN<20>) {
+        let payload = build_set_fee_payload(env, ACTION_SET_MESSAGE_FEE, 61, fee);
+        let base = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: Vec::new(env),
+            timestamp: 1,
+            nonce: 7,
+            emitter_chain,
+            emitter_address: BytesN::<32>::from_array(env, &emitter_address),
+            sequence: 42,
+            consistency_level: ConsistencyLevel::Confirmed,
+            payload,
+        };
+        let (signed, guardian_eth) = sign_vaa_with_key(env, base, [0x33u8; 32]);
+        (serialize_vaa(env, &signed), guardian_eth)
+    }
+
+    fn build_signed_guardian_upgrade_vaa(
+        env: &Env,
+        emitter_chain: u32,
+        emitter_address: [u8; 32],
+        new_index: u32,
+        new_key: BytesN<20>,
+    ) -> (Bytes, BytesN<20>) {
+        let payload = build_guardian_upgrade_payload(
+            env,
+            ACTION_GUARDIAN_SET_UPGRADE,
+            61,
+            new_index,
+            new_key,
+        );
+        let base = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: Vec::new(env),
+            timestamp: 2,
+            nonce: 8,
+            emitter_chain,
+            emitter_address: BytesN::<32>::from_array(env, &emitter_address),
+            sequence: 43,
+            consistency_level: ConsistencyLevel::Confirmed,
+            payload,
+        };
+        let (signed, guardian_eth) = sign_vaa_with_key(env, base, [0x33u8; 32]);
+        (serialize_vaa(env, &signed), guardian_eth)
+    }
+
+    #[test]
+    fn test_validate_governance_header_errors() {
+        let bad_module = BytesN::<32>::from_array(&Env::default(), &[1u8; 32]);
+        assert_eq!(
+            validate_governance_header(
+                &bad_module,
+                ACTION_SET_MESSAGE_FEE,
+                61,
+                ACTION_SET_MESSAGE_FEE
+            ),
+            Err(WormholeError::InvalidGovernanceModule)
+        );
+
+        let good_module = BytesN::<32>::from_array(&Env::default(), &MODULE_CORE);
+        assert_eq!(
+            validate_governance_header(&good_module, 9, 61, ACTION_SET_MESSAGE_FEE),
+            Err(WormholeError::InvalidGovernanceAction)
+        );
+        assert_eq!(
+            validate_governance_header(
+                &good_module,
+                ACTION_SET_MESSAGE_FEE,
+                2,
+                ACTION_SET_MESSAGE_FEE
+            ),
+            Err(WormholeError::InvalidGovernanceChain)
+        );
+        assert!(
+            validate_governance_header(
+                &good_module,
+                ACTION_SET_MESSAGE_FEE,
+                0,
+                ACTION_SET_MESSAGE_FEE
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_governance_header(
+                &good_module,
+                ACTION_SET_MESSAGE_FEE,
+                61,
+                ACTION_SET_MESSAGE_FEE
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_is_governance_vaa_consumed_invalid_bytes() {
+        let env = Env::default();
+        let malformed = Bytes::new(&env);
+        let res = is_governance_vaa_consumed_from_bytes(&env, &malformed);
+        assert_eq!(res, Err(WormholeError::InvalidVAAFormat));
+    }
+
+    #[test]
+    fn test_is_governance_vaa_consumed_roundtrip() {
+        let env = Env::default();
+        let contract_id = env.register(
+            Wormhole,
+            (
+                vec![&env, BytesN::<20>::from_array(&env, &[0u8; 20])],
+                BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER),
+            ),
+        );
+        let body = Bytes::from_slice(&env, &[1u8; 51]);
+        let mut vaa_bytes = Bytes::new(&env);
+        vaa_bytes.append(&Bytes::from_slice(&env, &[1u8]));
+        vaa_bytes.append(&Bytes::from_slice(&env, &0u32.to_be_bytes()));
+        vaa_bytes.append(&Bytes::from_slice(&env, &[0u8]));
+        vaa_bytes.append(&body);
+
+        env.as_contract(&contract_id, || {
+            let hash = keccak256_hash(&env, &body);
+            env.storage()
+                .persistent()
+                .set(&StorageKey::ConsumedGovernanceVAA(hash), &true);
+
+            let consumed = is_governance_vaa_consumed_from_bytes(&env, &vaa_bytes).unwrap();
+            assert!(consumed);
+        });
+    }
+
+    #[test]
+    fn test_submit_replay_and_source_checks() {
+        let env = Env::default();
+        env.ledger().set_timestamp(10);
+
+        let (vaa_bytes, guardian_eth) =
+            build_signed_set_fee_vaa(&env, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, 55);
+        let contract_id = deploy_with_guardian(&env, guardian_eth);
+
+        env.as_contract(&contract_id, || {
+            let first = SetMessageFeeAction::submit(&env, vaa_bytes.clone());
+            assert_eq!(first, Ok(()));
+            assert_eq!(get_message_fee(&env), 55);
+            let second = SetMessageFeeAction::submit(&env, vaa_bytes.clone());
+            assert_eq!(second, Err(WormholeError::GovernanceVAAAlreadyConsumed));
+        });
+        let events = env.events().all().filter_by_contract(&contract_id);
+        assert_eq!(
+            events,
+            vec![
+                &env,
+                (
+                    contract_id.clone(),
+                    vec![
+                        &env,
+                        Symbol::new(&env, "wormhole_core").into_val(&env),
+                        Symbol::new(&env, "fee_set").into_val(&env),
+                    ],
+                    55u64.into_val(&env),
+                )
+            ]
+        );
+
+        let (wrong_chain_vaa, guardian_eth_2) =
+            build_signed_set_fee_vaa(&env, 9, GOVERNANCE_EMITTER, 77);
+        let contract_id_2 = deploy_with_guardian(&env, guardian_eth_2);
+        env.as_contract(&contract_id_2, || {
+            let res = SetMessageFeeAction::submit(&env, wrong_chain_vaa.clone());
+            assert_eq!(res, Err(WormholeError::InvalidGovernanceChain));
+        });
+
+        let mut wrong_emitter = GOVERNANCE_EMITTER;
+        wrong_emitter[31] = 7;
+        let (wrong_emitter_vaa, guardian_eth_3) =
+            build_signed_set_fee_vaa(&env, GOVERNANCE_CHAIN_ID, wrong_emitter, 88);
+        let contract_id_3 = deploy_with_guardian(&env, guardian_eth_3);
+        env.as_contract(&contract_id_3, || {
+            let res = SetMessageFeeAction::submit(&env, wrong_emitter_vaa.clone());
+            assert_eq!(res, Err(WormholeError::InvalidGovernanceEmitter));
+        });
+    }
+
+    #[test]
+    fn test_cross_action_replay_domains_do_not_collide() {
+        let env = Env::default();
+        env.ledger().set_timestamp(20);
+
+        let (vaa_fee, guardian_eth) =
+            build_signed_set_fee_vaa(&env, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, 99);
+        let new_guardian = BytesN::<20>::from_array(&env, &[9u8; 20]);
+        let (vaa_guardian, _guardian_eth_2) = build_signed_guardian_upgrade_vaa(
+            &env,
+            GOVERNANCE_CHAIN_ID,
+            GOVERNANCE_EMITTER,
+            1,
+            new_guardian,
+        );
+
+        let contract_id = deploy_with_guardian(&env, guardian_eth);
+        env.as_contract(&contract_id, || {
+            assert_eq!(SetMessageFeeAction::submit(&env, vaa_fee.clone()), Ok(()));
+            assert_eq!(
+                GuardianSetUpgradeAction::submit(&env, vaa_guardian.clone()),
+                Ok(())
+            );
+            assert_eq!(get_message_fee(&env), 99);
+            assert_eq!(get_current_guardian_set_index(&env), 1);
+
+            assert_eq!(
+                SetMessageFeeAction::submit(&env, vaa_fee.clone()),
+                Err(WormholeError::GovernanceVAAAlreadyConsumed)
+            );
+            assert_eq!(
+                GuardianSetUpgradeAction::submit(&env, vaa_guardian.clone()),
+                Err(WormholeError::GovernanceVAAAlreadyConsumed)
+            );
+        });
+    }
+
+    #[test]
+    fn test_set_fee_payload_length_sanity() {
+        let env = Env::default();
+        let payload = build_set_fee_payload(&env, ACTION_SET_MESSAGE_FEE, 61, 1);
+        assert_eq!(payload.len(), SET_MESSAGE_FEE_PAYLOAD_MIN_LENGTH);
+    }
+}

--- a/stellar/contracts/wormhole-contract/src/governance/contract_upgrade.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/contract_upgrade.rs
@@ -1,0 +1,218 @@
+//! Contract upgrade governance action (`ACTION_CONTRACT_UPGRADE`, value 1).
+//!
+//! Allows guardians to upgrade the contract WASM by providing the hash of a
+//! new contract version. The contract is its own admin, so upgrades require
+//! guardian consensus rather than a separate admin key.
+
+use crate::governance::action::{
+    GovernanceAction, parse_governance_header, validate_governance_header,
+};
+use core::convert::TryFrom;
+use soroban_sdk::{Bytes, BytesN, Env, contractevent};
+use wormhole_soroban_client::{
+    ACTION_CONTRACT_UPGRADE, BytesReader, CONTRACT_UPGRADE_PAYLOAD_MIN_LENGTH, VAA, WormholeError,
+};
+
+/// Emitted when a contract upgrade is executed successfully.
+///
+/// Topics: `["wormhole_core", "upgrade"]`
+#[contractevent(topics = ["wormhole_core", "upgrade"], data_format = "single-value")]
+struct ContractUpgradeEvent {
+    /// WASM hash of the newly deployed contract version.
+    new_contract_hash: BytesN<32>,
+}
+
+/// Parsed payload for contract upgrade governance action.
+#[derive(Debug, PartialEq)]
+pub struct ContractUpgradePayload {
+    /// Module identifier (must be "Core").
+    pub module: BytesN<32>,
+    /// Governance action ID from the VAA header.
+    ///
+    /// Must equal `ACTION_CONTRACT_UPGRADE` (1); any other value is rejected by
+    /// `validate_governance_header`.
+    pub action: u8,
+    /// Target chain (0 for all, 61 for Stellar).
+    pub chain: u16,
+    /// WASM hash of the new contract to deploy.
+    pub new_contract_hash: BytesN<32>,
+}
+
+impl<'a> TryFrom<(&'a Env, &'a Bytes)> for ContractUpgradePayload {
+    type Error = WormholeError;
+
+    fn try_from(value: (&'a Env, &'a Bytes)) -> Result<Self, Self::Error> {
+        let (env, payload) = value;
+
+        if payload.len() < CONTRACT_UPGRADE_PAYLOAD_MIN_LENGTH {
+            return Err(WormholeError::InvalidPayload);
+        }
+
+        let mut reader = BytesReader::new(payload);
+        let (module, action, chain) = parse_governance_header(env, &mut reader)?;
+        let new_contract_hash = reader.read_bytes_n::<32>()?;
+
+        if reader.remaining() != 0 {
+            return Err(WormholeError::InvalidPayload);
+        }
+
+        Ok(ContractUpgradePayload {
+            module,
+            action,
+            chain,
+            new_contract_hash,
+        })
+    }
+}
+
+impl ContractUpgradePayload {
+    /// Validates the governance header matches expected values for upgrade
+    /// action.
+    fn validate(&self) -> Result<(), WormholeError> {
+        validate_governance_header(
+            &self.module,
+            self.action,
+            self.chain,
+            ACTION_CONTRACT_UPGRADE,
+        )
+    }
+}
+
+/// Governance action handler for contract upgrades.
+pub struct ContractUpgradeAction;
+
+impl GovernanceAction for ContractUpgradeAction {
+    type Payload = ContractUpgradePayload;
+
+    fn validate_payload(_env: &Env, payload: &Self::Payload) -> Result<(), WormholeError> {
+        payload.validate()
+    }
+
+    fn execute(env: &Env, _vaa: &VAA, payload: &Self::Payload) -> Result<(), WormholeError> {
+        env.deployer()
+            .update_current_contract_wasm(payload.new_contract_hash.clone());
+
+        ContractUpgradeEvent {
+            new_contract_hash: payload.new_contract_hash.clone(),
+        }
+        .publish(env);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Wormhole;
+    use soroban_sdk::{Bytes, BytesN, Env, vec};
+    use wormhole_soroban_client::{CHAIN_ID_STELLAR, MODULE_CORE};
+
+    fn build_payload(env: &Env, module: [u8; 32], action: u8, chain: u16) -> Bytes {
+        let mut payload = Bytes::new(env);
+        payload.append(&Bytes::from_array(env, &module));
+        payload.push_back(action);
+        payload.append(&Bytes::from_slice(env, &chain.to_be_bytes()));
+        payload.append(&Bytes::from_array(env, &[0xAB; 32]));
+        payload
+    }
+
+    #[test]
+    fn test_contract_upgrade_payload_rejects_short_payload() {
+        let env = Env::default();
+        let short = Bytes::from_slice(&env, &[0u8; 10]);
+        let res = ContractUpgradePayload::try_from((&env, &short));
+        assert_eq!(res, Err(WormholeError::InvalidPayload));
+    }
+
+    #[test]
+    fn test_contract_upgrade_validate_header_errors() {
+        let env = Env::default();
+        let bad_module = ContractUpgradePayload {
+            module: BytesN::from_array(&env, &[7u8; 32]),
+            action: ACTION_CONTRACT_UPGRADE,
+            chain: CHAIN_ID_STELLAR,
+            new_contract_hash: BytesN::from_array(&env, &[0u8; 32]),
+        };
+        assert_eq!(
+            bad_module.validate(),
+            Err(WormholeError::InvalidGovernanceModule)
+        );
+
+        let bad_action = ContractUpgradePayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: 9,
+            chain: CHAIN_ID_STELLAR,
+            new_contract_hash: BytesN::from_array(&env, &[0u8; 32]),
+        };
+        assert_eq!(
+            bad_action.validate(),
+            Err(WormholeError::InvalidGovernanceAction)
+        );
+
+        let bad_chain = ContractUpgradePayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: ACTION_CONTRACT_UPGRADE,
+            chain: 2,
+            new_contract_hash: BytesN::from_array(&env, &[0u8; 32]),
+        };
+        assert_eq!(
+            bad_chain.validate(),
+            Err(WormholeError::InvalidGovernanceChain)
+        );
+    }
+
+    #[test]
+    fn test_contract_upgrade_payload_parse_success() {
+        let env = Env::default();
+        let payload = build_payload(&env, MODULE_CORE, ACTION_CONTRACT_UPGRADE, CHAIN_ID_STELLAR);
+        let parsed = ContractUpgradePayload::try_from((&env, &payload)).unwrap();
+        assert_eq!(parsed.action, ACTION_CONTRACT_UPGRADE);
+        assert_eq!(parsed.chain, CHAIN_ID_STELLAR);
+        assert_eq!(parsed.module, BytesN::from_array(&env, &MODULE_CORE));
+        assert_eq!(
+            parsed.new_contract_hash,
+            BytesN::from_array(&env, &[0xAB; 32])
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidInput")]
+    fn test_contract_upgrade_execute_rejects_invalid_wasm_hash() {
+        let env = Env::default();
+        let contract_id = env.register(
+            Wormhole,
+            (
+                vec![&env, BytesN::<20>::from_array(&env, &[0u8; 20])],
+                BytesN::<32>::from_array(&env, &wormhole_soroban_client::GOVERNANCE_EMITTER),
+            ),
+        );
+
+        let wasm_hash = env.deployer().upload_contract_wasm(Bytes::from_slice(
+            &env,
+            &[0x00, 0x61, 0x73, 0x6d, 1, 0, 0, 0],
+        ));
+        let payload = ContractUpgradePayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: ACTION_CONTRACT_UPGRADE,
+            chain: CHAIN_ID_STELLAR,
+            new_contract_hash: wasm_hash,
+        };
+        let vaa = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: vec![&env],
+            timestamp: 0,
+            nonce: 0,
+            emitter_chain: 1,
+            emitter_address: BytesN::from_array(&env, &[0u8; 32]),
+            sequence: 0,
+            consistency_level: wormhole_soroban_client::ConsistencyLevel::Confirmed,
+            payload: Bytes::new(&env),
+        };
+
+        env.as_contract(&contract_id, || {
+            let _ = ContractUpgradeAction::execute(&env, &vaa, &payload);
+        });
+    }
+}

--- a/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/guardian_set.rs
@@ -1,0 +1,517 @@
+//! Guardian set upgrade governance action (`ACTION_GUARDIAN_SET_UPGRADE`, value
+//! 2).
+//!
+//! Manages guardian set storage and upgrades. Guardian sets are indexed
+//! sequentially starting from 0. When a new set is installed, the previous
+//! set is marked with an expiry timestamp (24 hours) to allow in-flight
+//! VAAs to still be processed.
+
+use crate::{
+    governance::action::{GovernanceAction, parse_governance_header, validate_governance_header},
+    storage::StorageKey,
+};
+use core::convert::TryFrom;
+use soroban_sdk::{Bytes, BytesN, Env, Vec, contractevent};
+use wormhole_soroban_client::{
+    ACTION_GUARDIAN_SET_UPGRADE, BytesReader, GUARDIAN_SET_EXPIRATION_TIME,
+    GUARDIAN_SET_UPGRADE_PAYLOAD_MIN_LENGTH, GuardianSetInfo, STORAGE_TTL_EXTENSION,
+    STORAGE_TTL_THRESHOLD, WormholeError,
+};
+
+/// Emitted when a guardian set upgrade is executed successfully.
+///
+/// Topics: `["wormhole_core", "guardian_set_upgrade"]`
+#[contractevent(topics = ["wormhole_core", "guardian_set_upgrade"])]
+struct GuardianSetUpgradeEvent {
+    /// Index of the newly installed guardian set.
+    new_guardian_set_index: u32,
+    /// Number of guardians in the new set.
+    guardian_count: u32,
+}
+
+/// Parsed payload for guardian set upgrade governance action.
+#[derive(Debug, PartialEq)]
+pub struct GuardianSetUpgradePayload {
+    /// Module identifier (must be "Core").
+    pub module: BytesN<32>,
+    /// Governance action ID from the VAA header.
+    ///
+    /// Must equal `ACTION_GUARDIAN_SET_UPGRADE` (2); any other value is
+    /// rejected by `validate_governance_header`.
+    pub action: u8,
+    /// Target chain (0 for all, 61 for Stellar).
+    pub chain: u16,
+    /// Index for the new guardian set (must be current + 1).
+    pub new_guardian_set_index: u32,
+    /// Ethereum addresses (20 bytes) of guardians in the new set.
+    pub new_guardian_set_keys: Vec<BytesN<20>>,
+}
+
+impl<'a> TryFrom<(&'a Env, &'a Bytes)> for GuardianSetUpgradePayload {
+    type Error = WormholeError;
+
+    fn try_from(value: (&'a Env, &'a Bytes)) -> Result<Self, Self::Error> {
+        let (env, payload) = value;
+
+        if payload.len() < GUARDIAN_SET_UPGRADE_PAYLOAD_MIN_LENGTH {
+            return Err(WormholeError::InvalidPayload);
+        }
+
+        let mut reader = BytesReader::new(payload);
+        let (module, action, chain) = parse_governance_header(env, &mut reader)?;
+
+        let new_guardian_set_index = reader.read_u32_be()?;
+        let guardian_count = reader.read_u8()?;
+
+        let mut keys = Vec::new(env);
+        for _ in 0..guardian_count {
+            let key = reader.read_bytes_n::<20>()?;
+            keys.push_back(BytesN::from_array(env, &key.to_array()));
+        }
+
+        if reader.remaining() != 0 {
+            return Err(WormholeError::InvalidPayload);
+        }
+
+        Ok(GuardianSetUpgradePayload {
+            module,
+            action,
+            chain,
+            new_guardian_set_index,
+            new_guardian_set_keys: keys,
+        })
+    }
+}
+
+impl GuardianSetUpgradePayload {
+    fn validate(&self, env: &Env) -> Result<(), WormholeError> {
+        validate_governance_header(
+            &self.module,
+            self.action,
+            self.chain,
+            ACTION_GUARDIAN_SET_UPGRADE,
+        )?;
+
+        let current_index = get_current_guardian_set_index(env);
+        if self.new_guardian_set_index != current_index.saturating_add(1) {
+            return Err(WormholeError::InvalidGuardianSetSequence);
+        }
+
+        if self.new_guardian_set_keys.is_empty() {
+            return Err(WormholeError::EmptyGuardianSet);
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns the current active guardian set index.
+pub fn get_current_guardian_set_index(env: &Env) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::CurrentGuardianSetIndex)
+        .unwrap_or(0)
+}
+
+/// Updates the current guardian set index pointer.
+pub fn set_current_index(env: &Env, index: u32) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::CurrentGuardianSetIndex, &index);
+
+    env.storage().persistent().extend_ttl(
+        &StorageKey::CurrentGuardianSetIndex,
+        STORAGE_TTL_THRESHOLD,
+        STORAGE_TTL_EXTENSION,
+    );
+}
+
+/// Retrieves a guardian set by index.
+pub fn get_guardian_set(env: &Env, index: u32) -> Result<GuardianSetInfo, WormholeError> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::GuardianSet(index))
+        .ok_or(WormholeError::GuardianSetNotFound)
+}
+
+/// Returns the expiry timestamp for a guardian set, if set.
+pub fn get_guardian_set_expiry(env: &Env, index: u32) -> Option<u64> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::GuardianSetExpiry(index))
+}
+
+/// Stores a new guardian set at the given index.
+///
+/// Index 0 is only valid during constructor (guardian set won't exist yet).
+/// Subsequent indices must be strictly sequential (current + 1).
+/// Cannot overwrite existing guardian sets.
+pub fn store(env: &Env, index: u32, set: GuardianSetInfo) -> Result<(), WormholeError> {
+    let current_index = get_current_guardian_set_index(env);
+
+    // Index 0 is only valid during constructor (guardian set won't exist yet)
+    // All other indices must be current + 1 for proper sequencing
+    if index != 0 && index != current_index.saturating_add(1) {
+        return Err(WormholeError::InvalidGuardianSetSequence);
+    }
+
+    // Cannot overwrite existing guardian sets (including index 0 after constructor)
+    if get_guardian_set(env, index).is_ok() {
+        return Err(WormholeError::GuardianSetAlreadyExists);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&StorageKey::GuardianSet(index), &set);
+
+    env.storage().persistent().extend_ttl(
+        &StorageKey::GuardianSet(index),
+        STORAGE_TTL_THRESHOLD,
+        STORAGE_TTL_EXTENSION,
+    );
+
+    Ok(())
+}
+
+/// Sets the expiry timestamp for a guardian set.
+fn set_expiry(env: &Env, index: u32, expiry: u64) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::GuardianSetExpiry(index), &expiry);
+
+    env.storage().persistent().extend_ttl(
+        &StorageKey::GuardianSetExpiry(index),
+        STORAGE_TTL_THRESHOLD,
+        STORAGE_TTL_EXTENSION,
+    );
+}
+
+/// Governance action handler for guardian set upgrades.
+pub struct GuardianSetUpgradeAction;
+
+impl GovernanceAction for GuardianSetUpgradeAction {
+    type Payload = GuardianSetUpgradePayload;
+
+    fn validate_payload(env: &Env, payload: &Self::Payload) -> Result<(), WormholeError> {
+        payload.validate(env)
+    }
+
+    fn execute(
+        env: &Env,
+        vaa: &crate::vaa::VAA,
+        payload: &Self::Payload,
+    ) -> Result<(), WormholeError> {
+        let old_index = get_current_guardian_set_index(env);
+
+        let expiry_time =
+            u64::from(vaa.timestamp).saturating_add(u64::from(GUARDIAN_SET_EXPIRATION_TIME));
+        set_expiry(env, old_index, expiry_time);
+
+        let new_set = GuardianSetInfo {
+            keys: payload.new_guardian_set_keys.clone(),
+            creation_time: env.ledger().timestamp(),
+        };
+        store(env, payload.new_guardian_set_index, new_set)?;
+
+        set_current_index(env, payload.new_guardian_set_index);
+
+        GuardianSetUpgradeEvent {
+            new_guardian_set_index: payload.new_guardian_set_index,
+            guardian_count: payload.new_guardian_set_keys.len(),
+        }
+        .publish(env);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Wormhole;
+    use soroban_sdk::{Bytes, BytesN, Env, IntoVal, Symbol, Val, testutils::Events, vec};
+    use wormhole_soroban_client::{
+        CHAIN_ID_STELLAR, ConsistencyLevel, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, MODULE_CORE,
+        Signature, VAA,
+    };
+
+    fn deploy_initialized(env: &Env) -> soroban_sdk::Address {
+        let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
+        let initial_guardians = vec![env, guardian];
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
+        env.register(Wormhole, (initial_guardians, governance_emitter))
+    }
+
+    fn build_payload(
+        env: &Env,
+        module: [u8; 32],
+        action: u8,
+        chain: u16,
+        new_index: u32,
+        keys: &[BytesN<20>],
+    ) -> Bytes {
+        let mut payload = Bytes::new(env);
+        payload.append(&Bytes::from_array(env, &module));
+        payload.push_back(action);
+        payload.append(&Bytes::from_slice(env, &chain.to_be_bytes()));
+        payload.append(&Bytes::from_slice(env, &new_index.to_be_bytes()));
+        payload.push_back(keys.len() as u8);
+        for k in keys {
+            payload.append(&Bytes::from_array(env, &k.to_array()));
+        }
+        payload
+    }
+
+    fn serialize_vaa(env: &Env, vaa: &VAA) -> Bytes {
+        let mut out = Bytes::new(env);
+        out.push_back(vaa.version as u8);
+        out.append(&Bytes::from_slice(
+            env,
+            &vaa.guardian_set_index.to_be_bytes(),
+        ));
+        out.push_back(vaa.signatures.len() as u8);
+        for sig in vaa.signatures.iter() {
+            out.push_back(sig.guardian_index as u8);
+            out.append(&Bytes::from_array(env, &sig.r.to_array()));
+            out.append(&Bytes::from_array(env, &sig.s.to_array()));
+            out.push_back(sig.v as u8);
+        }
+        out.append(&Bytes::from_slice(env, &vaa.timestamp.to_be_bytes()));
+        out.append(&Bytes::from_slice(env, &vaa.nonce.to_be_bytes()));
+        out.append(&Bytes::from_slice(
+            env,
+            &(vaa.emitter_chain as u16).to_be_bytes(),
+        ));
+        out.append(&Bytes::from_array(env, &vaa.emitter_address.to_array()));
+        out.append(&Bytes::from_slice(env, &vaa.sequence.to_be_bytes()));
+        out.push_back(vaa.consistency_level as u8);
+        out.append(&vaa.payload);
+        out
+    }
+
+    fn sign_vaa_with_key(env: &Env, mut vaa: VAA, sk_bytes: [u8; 32]) -> (VAA, BytesN<20>) {
+        let body = vaa.serialize_body(env);
+        let body_hash: Bytes = crate::utils::keccak256_hash(env, &body).into();
+        let double_hash = env.crypto().keccak256(&body_hash).to_array();
+        let secp = secp256k1::Secp256k1::new();
+        let sk = secp256k1::SecretKey::from_byte_array(sk_bytes).unwrap();
+        let pk = secp256k1::PublicKey::from_secret_key(&secp, &sk);
+        let pk_bytes65 = BytesN::<65>::from_array(env, &pk.serialize_uncompressed());
+        let guardian_eth = crate::utils::pubkey_to_eth_address(env, &pk_bytes65);
+        let message = secp256k1::Message::from_digest(double_hash);
+        let sig = secp.sign_ecdsa_recoverable(message, &sk);
+        let (recid, compact64) = sig.serialize_compact();
+        let mut r = [0u8; 32];
+        let mut s = [0u8; 32];
+        r.copy_from_slice(&compact64[0..32]);
+        s.copy_from_slice(&compact64[32..64]);
+        let mut sigs = Vec::new(env);
+        sigs.push_back(Signature {
+            guardian_index: 0,
+            r: BytesN::from_array(env, &r),
+            s: BytesN::from_array(env, &s),
+            v: i32::from(recid) as u32,
+        });
+        vaa.signatures = sigs;
+        (vaa, guardian_eth)
+    }
+
+    #[test]
+    fn test_guardian_set_upgrade_payload_rejects_short_payload() {
+        let env = Env::default();
+        let short = Bytes::from_slice(&env, &[0u8; 10]);
+        let res = GuardianSetUpgradePayload::try_from((&env, &short));
+        assert_eq!(res, Err(WormholeError::InvalidPayload));
+    }
+
+    #[test]
+    fn test_guardian_set_upgrade_validate_rejects_non_sequential_index() {
+        let env = Env::default();
+        let contract_id = deploy_initialized(&env);
+        let payload = GuardianSetUpgradePayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: ACTION_GUARDIAN_SET_UPGRADE,
+            chain: CHAIN_ID_STELLAR,
+            new_guardian_set_index: 2,
+            new_guardian_set_keys: vec![&env, BytesN::from_array(&env, &[9u8; 20])],
+        };
+
+        env.as_contract(&contract_id, || {
+            let res = payload.validate(&env);
+            assert_eq!(res, Err(WormholeError::InvalidGuardianSetSequence));
+        });
+    }
+
+    #[test]
+    fn test_guardian_set_upgrade_validate_rejects_empty_keys() {
+        let env = Env::default();
+        let contract_id = deploy_initialized(&env);
+        let payload = GuardianSetUpgradePayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: ACTION_GUARDIAN_SET_UPGRADE,
+            chain: CHAIN_ID_STELLAR,
+            new_guardian_set_index: 1,
+            new_guardian_set_keys: Vec::new(&env),
+        };
+
+        env.as_contract(&contract_id, || {
+            let res = payload.validate(&env);
+            assert_eq!(res, Err(WormholeError::EmptyGuardianSet));
+        });
+    }
+
+    #[test]
+    fn test_guardian_set_upgrade_execute_updates_state() {
+        let env = Env::default();
+        let contract_id = deploy_initialized(&env);
+        let new_guardian = BytesN::<20>::from_array(&env, &[7u8; 20]);
+        let bytes = build_payload(
+            &env,
+            MODULE_CORE,
+            ACTION_GUARDIAN_SET_UPGRADE,
+            CHAIN_ID_STELLAR,
+            1,
+            core::slice::from_ref(&new_guardian),
+        );
+        let payload = GuardianSetUpgradePayload::try_from((&env, &bytes)).unwrap();
+        let vaa = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: vec![&env],
+            timestamp: 100,
+            nonce: 1,
+            emitter_chain: GOVERNANCE_CHAIN_ID,
+            emitter_address: BytesN::from_array(&env, &[0u8; 32]),
+            sequence: 1,
+            consistency_level: wormhole_soroban_client::ConsistencyLevel::Confirmed,
+            payload: Bytes::new(&env),
+        };
+
+        env.as_contract(&contract_id, || {
+            GuardianSetUpgradeAction::execute(&env, &vaa, &payload).unwrap();
+
+            assert_eq!(get_current_guardian_set_index(&env), 1);
+            let g1 = get_guardian_set(&env, 1).unwrap();
+            assert_eq!(g1.keys.len(), 1);
+            assert_eq!(g1.keys.get(0).unwrap(), new_guardian);
+
+            let expiry = get_guardian_set_expiry(&env, 0).unwrap();
+            assert_eq!(
+                expiry,
+                u64::from(vaa.timestamp) + u64::from(GUARDIAN_SET_EXPIRATION_TIME)
+            );
+        });
+
+        let events = env.events().all().filter_by_contract(&contract_id);
+        let guardian_count_val: Val = 1u32.into_val(&env);
+        let new_index_val: Val = 1u32.into_val(&env);
+        assert_eq!(
+            events,
+            vec![
+                &env,
+                (
+                    contract_id,
+                    vec![
+                        &env,
+                        Symbol::new(&env, "wormhole_core").into_val(&env),
+                        Symbol::new(&env, "guardian_set_upgrade").into_val(&env),
+                    ],
+                    soroban_sdk::map![
+                        &env,
+                        (Symbol::new(&env, "guardian_count"), guardian_count_val),
+                        (Symbol::new(&env, "new_guardian_set_index"), new_index_val),
+                    ]
+                    .into_val(&env),
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn test_store_rejects_overwrite() {
+        let env = Env::default();
+        let contract_id = deploy_initialized(&env);
+        env.as_contract(&contract_id, || {
+            let set = GuardianSetInfo {
+                keys: vec![&env, BytesN::from_array(&env, &[1u8; 20])],
+                creation_time: 0,
+            };
+            let res = store(&env, 0, set);
+            assert_eq!(res, Err(WormholeError::GuardianSetAlreadyExists));
+        });
+    }
+
+    #[test]
+    fn test_submit_rejects_malicious_old_guardian_index() {
+        let env = Env::default();
+
+        let payload = build_payload(
+            &env,
+            MODULE_CORE,
+            ACTION_GUARDIAN_SET_UPGRADE,
+            CHAIN_ID_STELLAR,
+            0,
+            &[BytesN::<20>::from_array(&env, &[5u8; 20])],
+        );
+        let base = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: Vec::new(&env),
+            timestamp: 1,
+            nonce: 1,
+            emitter_chain: GOVERNANCE_CHAIN_ID,
+            emitter_address: BytesN::from_array(&env, &GOVERNANCE_EMITTER),
+            sequence: 1,
+            consistency_level: ConsistencyLevel::Confirmed,
+            payload,
+        };
+        let (signed, guardian_eth) = sign_vaa_with_key(&env, base, [0x44u8; 32]);
+        let contract_id = env.register(
+            Wormhole,
+            (
+                vec![&env, guardian_eth],
+                BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER),
+            ),
+        );
+        let vaa_bytes = serialize_vaa(&env, &signed);
+
+        env.as_contract(&contract_id, || {
+            let res = GuardianSetUpgradeAction::submit(&env, vaa_bytes.clone());
+            assert_eq!(res, Err(WormholeError::InvalidGuardianSetSequence));
+        });
+    }
+
+    #[test]
+    fn test_guardian_set_expiry_arithmetic_bounds() {
+        let env = Env::default();
+        let contract_id = deploy_initialized(&env);
+        let new_guardian = BytesN::<20>::from_array(&env, &[9u8; 20]);
+        let payload = GuardianSetUpgradePayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: ACTION_GUARDIAN_SET_UPGRADE,
+            chain: CHAIN_ID_STELLAR,
+            new_guardian_set_index: 1,
+            new_guardian_set_keys: vec![&env, new_guardian],
+        };
+        let vaa = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: vec![&env],
+            timestamp: u32::MAX,
+            nonce: 0,
+            emitter_chain: GOVERNANCE_CHAIN_ID,
+            emitter_address: BytesN::from_array(&env, &[0u8; 32]),
+            sequence: 0,
+            consistency_level: ConsistencyLevel::Confirmed,
+            payload: Bytes::new(&env),
+        };
+        env.as_contract(&contract_id, || {
+            GuardianSetUpgradeAction::execute(&env, &vaa, &payload).unwrap();
+            let expiry = get_guardian_set_expiry(&env, 0).unwrap();
+            assert_eq!(
+                expiry,
+                u64::from(u32::MAX).saturating_add(u64::from(GUARDIAN_SET_EXPIRATION_TIME))
+            );
+        });
+    }
+}

--- a/stellar/contracts/wormhole-contract/src/governance/mod.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/mod.rs
@@ -1,0 +1,36 @@
+//! Governance action processing for the Wormhole Core contract.
+//!
+//! Implements the four governance actions defined by Wormhole.
+//!
+//! Action IDs are encoded in the VAA governance header `action` byte and
+//! validated by `validate_governance_header` in each action module.
+//! Mappings are:
+//! - Contract upgrade (`ACTION_CONTRACT_UPGRADE`, 1)
+//! - Guardian set upgrade (`ACTION_GUARDIAN_SET_UPGRADE`, 2)
+//! - Set message fee (`ACTION_SET_MESSAGE_FEE`, 3)
+//! - Transfer fees (`ACTION_TRANSFER_FEES`, 4)
+//!
+//! All actions require VAAs signed by a quorum of guardians and originating
+//! from the governance chain (Solana) and emitter address.
+
+mod action;
+mod contract_upgrade;
+pub mod guardian_set;
+mod set_message_fee;
+mod transfer_fees;
+
+pub use action::GovernanceAction;
+pub use contract_upgrade::ContractUpgradeAction;
+pub use guardian_set::GuardianSetUpgradeAction;
+pub use set_message_fee::{SetMessageFeeAction, get_message_fee};
+pub use transfer_fees::TransferFeesAction;
+
+use soroban_sdk::{Bytes, Env};
+use wormhole_soroban_client::WormholeError;
+
+/// Checks if a governance VAA has been consumed (replay protection).
+///
+/// Returns `Ok(true)` if consumed, `Ok(false)` if not. Errors only on parse failure.
+pub fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<bool, WormholeError> {
+    action::is_governance_vaa_consumed_from_bytes(&env, &vaa_bytes)
+}

--- a/stellar/contracts/wormhole-contract/src/governance/set_message_fee.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/set_message_fee.rs
@@ -1,0 +1,260 @@
+//! Set message fee governance action (`ACTION_SET_MESSAGE_FEE`, value 3).
+//!
+//! Allows guardians to update the fee charged for posting cross-chain messages.
+//! The fee is denominated in stroops (10^-7 XLM).
+
+use crate::{
+    governance::action::{GovernanceAction, parse_governance_header, validate_governance_header},
+    storage::StorageKey,
+};
+use core::convert::TryFrom;
+use soroban_sdk::{Bytes, BytesN, Env, contractevent};
+use wormhole_soroban_client::{
+    ACTION_SET_MESSAGE_FEE, BytesReader, SET_MESSAGE_FEE_PAYLOAD_MIN_LENGTH, STORAGE_TTL_EXTENSION,
+    STORAGE_TTL_THRESHOLD, U256_PADDING_BYTES, VAA, WormholeError,
+};
+
+/// Emitted when the message fee is updated.
+#[contractevent(topics = ["wormhole_core", "fee_set"], data_format = "single-value")]
+pub struct MessageFeeSetEvent {
+    /// New fee in stroops.
+    pub fee: u64,
+}
+
+/// Parsed payload for set message fee governance action.
+#[derive(Debug, PartialEq)]
+pub struct SetMessageFeePayload {
+    /// Module identifier (must be "Core").
+    pub module: BytesN<32>,
+    /// Governance action ID from the VAA header.
+    ///
+    /// Must equal `ACTION_SET_MESSAGE_FEE` (3); any other value is rejected by
+    /// `validate_governance_header`.
+    pub action: u8,
+    /// Target chain (0 for all, 61 for Stellar).
+    pub chain: u16,
+    /// New message fee in stroops.
+    pub fee: u64,
+}
+
+impl<'a> TryFrom<(&'a Env, &'a Bytes)> for SetMessageFeePayload {
+    type Error = WormholeError;
+
+    fn try_from(value: (&'a Env, &'a Bytes)) -> Result<Self, Self::Error> {
+        let (env, payload) = value;
+
+        if payload.len() < SET_MESSAGE_FEE_PAYLOAD_MIN_LENGTH {
+            return Err(WormholeError::InvalidPayload);
+        }
+
+        let mut reader = BytesReader::new(payload);
+        let (module, action, chain) = parse_governance_header(env, &mut reader)?;
+
+        reader.skip(U256_PADDING_BYTES)?;
+        let fee = reader.read_u64_be()?;
+
+        if reader.remaining() != 0 {
+            return Err(WormholeError::InvalidPayload);
+        }
+
+        Ok(SetMessageFeePayload {
+            module,
+            action,
+            chain,
+            fee,
+        })
+    }
+}
+
+impl SetMessageFeePayload {
+    fn validate(&self) -> Result<(), WormholeError> {
+        validate_governance_header(
+            &self.module,
+            self.action,
+            self.chain,
+            ACTION_SET_MESSAGE_FEE,
+        )
+    }
+}
+
+/// Returns the current message fee in stroops, or 0 if not set.
+pub fn get_message_fee(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::MessageFee)
+        .unwrap_or(0)
+}
+
+fn set_message_fee(env: &Env, fee: u64) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::MessageFee, &fee);
+
+    env.storage().persistent().extend_ttl(
+        &StorageKey::MessageFee,
+        STORAGE_TTL_THRESHOLD,
+        STORAGE_TTL_EXTENSION,
+    );
+}
+
+/// Governance action handler for setting the message fee.
+pub struct SetMessageFeeAction;
+
+impl GovernanceAction for SetMessageFeeAction {
+    type Payload = SetMessageFeePayload;
+
+    fn validate_payload(_env: &Env, payload: &Self::Payload) -> Result<(), WormholeError> {
+        payload.validate()
+    }
+
+    fn execute(env: &Env, _vaa: &VAA, payload: &Self::Payload) -> Result<(), WormholeError> {
+        set_message_fee(env, payload.fee);
+        MessageFeeSetEvent { fee: payload.fee }.publish(env);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Wormhole;
+    use soroban_sdk::{Bytes, BytesN, IntoVal, Symbol, testutils::Events, vec};
+    use wormhole_soroban_client::{
+        CHAIN_ID_STELLAR, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, MODULE_CORE,
+    };
+
+    fn build_payload(env: &Env, module: [u8; 32], action: u8, chain: u16, fee: u64) -> Bytes {
+        let mut payload = Bytes::new(env);
+        payload.append(&Bytes::from_array(env, &module));
+        payload.push_back(action);
+        payload.append(&Bytes::from_slice(env, &chain.to_be_bytes()));
+        payload.append(&Bytes::from_array(env, &[0u8; 24]));
+        payload.append(&Bytes::from_slice(env, &fee.to_be_bytes()));
+        payload
+    }
+
+    fn deploy_initialized(env: &Env) -> soroban_sdk::Address {
+        let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
+        let initial_guardians = vec![env, guardian];
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
+        env.register(Wormhole, (initial_guardians, governance_emitter))
+    }
+
+    #[test]
+    fn test_get_message_fee_default_zero() {
+        let env = Env::default();
+        let contract_id = deploy_initialized(&env);
+        env.as_contract(&contract_id, || {
+            assert_eq!(get_message_fee(&env), 0);
+        });
+    }
+
+    #[test]
+    fn test_set_message_fee_payload_parses_u256_padded_fee() {
+        let env = Env::default();
+        let payload = build_payload(
+            &env,
+            MODULE_CORE,
+            ACTION_SET_MESSAGE_FEE,
+            CHAIN_ID_STELLAR,
+            1234,
+        );
+
+        let parsed = SetMessageFeePayload::try_from((&env, &payload)).unwrap();
+        assert_eq!(parsed.action, ACTION_SET_MESSAGE_FEE);
+        assert_eq!(parsed.chain, CHAIN_ID_STELLAR);
+        assert_eq!(parsed.fee, 1234);
+        assert_eq!(parsed.module, BytesN::<32>::from_array(&env, &MODULE_CORE));
+    }
+
+    #[test]
+    fn test_set_message_fee_payload_rejects_short_payload() {
+        let env = Env::default();
+        let short = Bytes::from_slice(&env, &[0u8; 10]);
+        let res = SetMessageFeePayload::try_from((&env, &short));
+        assert_eq!(res, Err(WormholeError::InvalidPayload));
+    }
+
+    #[test]
+    fn test_set_message_fee_validate_header_errors() {
+        let env = Env::default();
+        let bad_module = SetMessageFeePayload {
+            module: BytesN::<32>::from_array(&env, &[9u8; 32]),
+            action: ACTION_SET_MESSAGE_FEE,
+            chain: CHAIN_ID_STELLAR,
+            fee: 1,
+        };
+        assert_eq!(
+            bad_module.validate(),
+            Err(WormholeError::InvalidGovernanceModule)
+        );
+
+        let bad_action = SetMessageFeePayload {
+            module: BytesN::<32>::from_array(&env, &MODULE_CORE),
+            action: 99,
+            chain: CHAIN_ID_STELLAR,
+            fee: 1,
+        };
+        assert_eq!(
+            bad_action.validate(),
+            Err(WormholeError::InvalidGovernanceAction)
+        );
+
+        let bad_chain = SetMessageFeePayload {
+            module: BytesN::<32>::from_array(&env, &MODULE_CORE),
+            action: ACTION_SET_MESSAGE_FEE,
+            chain: 2,
+            fee: 1,
+        };
+        assert_eq!(
+            bad_chain.validate(),
+            Err(WormholeError::InvalidGovernanceChain)
+        );
+    }
+
+    #[test]
+    fn test_set_message_fee_execute_updates_state_and_event() {
+        let env = Env::default();
+        let contract_id = deploy_initialized(&env);
+        let payload = SetMessageFeePayload {
+            module: BytesN::<32>::from_array(&env, &MODULE_CORE),
+            action: ACTION_SET_MESSAGE_FEE,
+            chain: CHAIN_ID_STELLAR,
+            fee: 777,
+        };
+        let vaa = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: vec![&env],
+            timestamp: 0,
+            nonce: 0,
+            emitter_chain: GOVERNANCE_CHAIN_ID,
+            emitter_address: BytesN::from_array(&env, &[0u8; 32]),
+            sequence: 0,
+            consistency_level: wormhole_soroban_client::ConsistencyLevel::Confirmed,
+            payload: Bytes::new(&env),
+        };
+
+        env.as_contract(&contract_id, || {
+            SetMessageFeeAction::execute(&env, &vaa, &payload).unwrap();
+            assert_eq!(get_message_fee(&env), 777);
+        });
+
+        let events = env.events().all().filter_by_contract(&contract_id);
+        assert_eq!(
+            events,
+            vec![
+                &env,
+                (
+                    contract_id,
+                    vec![
+                        &env,
+                        Symbol::new(&env, "wormhole_core").into_val(&env),
+                        Symbol::new(&env, "fee_set").into_val(&env),
+                    ],
+                    777u64.into_val(&env),
+                )
+            ]
+        );
+    }
+}

--- a/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
+++ b/stellar/contracts/wormhole-contract/src/governance/transfer_fees.rs
@@ -1,0 +1,346 @@
+//! Transfer fees governance action (`ACTION_TRANSFER_FEES`, value 4).
+//!
+//! Allows guardians to withdraw accumulated message fees from the contract.
+
+use crate::{
+    governance::action::{GovernanceAction, parse_governance_header, validate_governance_header},
+    utils::{address_from_ed25519_pk_bytes, get_native_token_address},
+};
+use core::convert::TryFrom;
+use soroban_sdk::{Address, Bytes, BytesN, Env, contractevent, token};
+use wormhole_soroban_client::{
+    ACTION_TRANSFER_FEES, BytesReader, TRANSFER_FEES_PAYLOAD_MIN_LENGTH, U256_PADDING_BYTES, VAA,
+    WormholeError,
+};
+
+/// Event published when fees are transferred out.
+///
+/// Topics: ["wormhole_core", "fee_transfer"]
+/// - "wormhole_core": Namespace for all core contract governance/lifecycle
+///   events
+#[contractevent(topics = ["wormhole_core", "fee_transfer"])]
+pub struct FeeTransferEvent {
+    pub amount: u64,
+    pub recipient: Address,
+}
+
+/// Parsed payload for transfer fees governance action.
+#[derive(Debug, PartialEq)]
+pub struct TransferFeesPayload {
+    /// Module identifier (must be "Core").
+    pub module: BytesN<32>,
+    /// Governance action ID from the VAA header.
+    ///
+    /// Must equal `ACTION_TRANSFER_FEES` (4); any other value is rejected by
+    /// `validate_governance_header`.
+    pub action: u8,
+    /// Target chain (0 for all, 61 for Stellar).
+    pub chain: u16,
+    /// Amount to transfer in stroops.
+    pub amount: u64,
+    /// Stellar address to receive the fees.
+    pub recipient: Address,
+}
+
+impl<'a> TryFrom<(&'a Env, &'a Bytes)> for TransferFeesPayload {
+    type Error = WormholeError;
+
+    fn try_from(value: (&'a Env, &'a Bytes)) -> Result<Self, Self::Error> {
+        let (env, payload) = value;
+
+        if payload.len() < TRANSFER_FEES_PAYLOAD_MIN_LENGTH {
+            return Err(WormholeError::InvalidPayload);
+        }
+
+        let mut reader = BytesReader::new(payload);
+        let (module, action, chain) = parse_governance_header(env, &mut reader)?;
+
+        reader.skip(U256_PADDING_BYTES)?;
+        let amount = reader.read_u64_be()?;
+
+        let recipient_pk_bytes: BytesN<32> = reader.read_bytes_n::<32>()?;
+        let recipient = address_from_ed25519_pk_bytes(env, &recipient_pk_bytes);
+
+        if reader.remaining() != 0 {
+            return Err(WormholeError::InvalidPayload);
+        }
+
+        Ok(TransferFeesPayload {
+            module,
+            action,
+            chain,
+            amount,
+            recipient,
+        })
+    }
+}
+
+impl TransferFeesPayload {
+    fn validate(&self, env: &Env) -> Result<(), WormholeError> {
+        validate_governance_header(&self.module, self.action, self.chain, ACTION_TRANSFER_FEES)?;
+
+        let native_token_address = get_native_token_address(env);
+        let token_client = token::TokenClient::new(env, &native_token_address);
+        let contract_address = env.current_contract_address();
+        let current_balance = u64::try_from(token_client.balance(&contract_address)).unwrap_or(0);
+
+        if self.amount > current_balance {
+            return Err(WormholeError::InsufficientFees);
+        }
+
+        Ok(())
+    }
+}
+
+/// Governance action handler for fee transfers.
+pub struct TransferFeesAction;
+
+impl GovernanceAction for TransferFeesAction {
+    type Payload = TransferFeesPayload;
+
+    fn validate_payload(env: &Env, payload: &Self::Payload) -> Result<(), WormholeError> {
+        payload.validate(env)
+    }
+
+    fn execute(env: &Env, _vaa: &VAA, payload: &Self::Payload) -> Result<(), WormholeError> {
+        let native_token_address = get_native_token_address(env);
+        let token_client = token::TokenClient::new(env, &native_token_address);
+        let contract_address = env.current_contract_address();
+
+        token_client.transfer(
+            &contract_address,
+            &payload.recipient,
+            &i128::from(payload.amount),
+        );
+
+        FeeTransferEvent {
+            amount: payload.amount,
+            recipient: payload.recipient.clone(),
+        }
+        .publish(env);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Wormhole;
+    use soroban_sdk::{
+        Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Val, contract, contractimpl,
+        contracttype,
+        testutils::{Address as TestAddress, Events, Ledger},
+    };
+    use wormhole_soroban_client::{
+        CHAIN_ID_STELLAR, GOVERNANCE_EMITTER, MODULE_CORE, NATIVE_TOKEN_ADDRESS,
+    };
+
+    #[contracttype]
+    #[derive(Clone)]
+    enum MockTokenStorage {
+        Balance(Address),
+    }
+
+    #[contract]
+    struct MockNativeToken;
+
+    #[contractimpl]
+    impl MockNativeToken {
+        pub fn set_balance(env: Env, id: Address, amount: i128) {
+            env.storage()
+                .persistent()
+                .set(&MockTokenStorage::Balance(id), &amount);
+        }
+
+        pub fn balance(env: Env, id: Address) -> i128 {
+            env.storage()
+                .persistent()
+                .get(&MockTokenStorage::Balance(id))
+                .unwrap_or(0)
+        }
+
+        pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+            let from_balance = Self::balance(env.clone(), from.clone());
+            if from_balance < amount {
+                panic!("insufficient");
+            }
+            let to_balance = Self::balance(env.clone(), to.clone());
+            Self::set_balance(env.clone(), from, from_balance - amount);
+            Self::set_balance(env, to, to_balance + amount);
+        }
+    }
+
+    fn install_native_token_mock(env: &Env) -> (Address, MockNativeTokenClient<'_>) {
+        let native = Address::from_string(&String::from_str(env, NATIVE_TOKEN_ADDRESS));
+        env.register_at(&native, MockNativeToken, ());
+        let client = MockNativeTokenClient::new(env, &native);
+        (native, client)
+    }
+
+    fn deploy_initialized(env: &Env) -> Address {
+        let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
+        let initial_guardians = soroban_sdk::vec![env, guardian];
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
+        env.register(Wormhole, (initial_guardians, governance_emitter))
+    }
+
+    fn build_payload(env: &Env, module: [u8; 32], action: u8, chain: u16, amount: u64) -> Bytes {
+        let mut payload = Bytes::new(env);
+        payload.append(&Bytes::from_array(env, &module));
+        payload.push_back(action);
+        payload.append(&Bytes::from_slice(env, &chain.to_be_bytes()));
+        payload.append(&Bytes::from_array(env, &[0u8; 24]));
+        payload.append(&Bytes::from_slice(env, &amount.to_be_bytes()));
+        payload.append(&Bytes::from_array(env, &[7u8; 32]));
+        payload
+    }
+
+    #[test]
+    fn test_transfer_fees_payload_parses_amount_and_recipient() {
+        let env = Env::default();
+        let payload = build_payload(
+            &env,
+            MODULE_CORE,
+            ACTION_TRANSFER_FEES,
+            CHAIN_ID_STELLAR,
+            12345,
+        );
+        let parsed = TransferFeesPayload::try_from((&env, &payload)).unwrap();
+
+        assert_eq!(parsed.action, ACTION_TRANSFER_FEES);
+        assert_eq!(parsed.chain, CHAIN_ID_STELLAR);
+        assert_eq!(parsed.amount, 12345);
+        assert_eq!(parsed.module, BytesN::from_array(&env, &MODULE_CORE));
+    }
+
+    #[test]
+    fn test_transfer_fees_payload_rejects_short_payload() {
+        let env = Env::default();
+        let short = Bytes::from_slice(&env, &[0u8; 10]);
+        let res = TransferFeesPayload::try_from((&env, &short));
+        assert_eq!(res, Err(WormholeError::InvalidPayload));
+    }
+
+    #[test]
+    fn test_transfer_fees_validate_header_errors() {
+        let env = Env::default();
+        let recipient = address_from_ed25519_pk_bytes(&env, &BytesN::from_array(&env, &[1u8; 32]));
+
+        let bad_module = TransferFeesPayload {
+            module: BytesN::from_array(&env, &[9u8; 32]),
+            action: ACTION_TRANSFER_FEES,
+            chain: CHAIN_ID_STELLAR,
+            amount: 1,
+            recipient: recipient.clone(),
+        };
+        assert_eq!(
+            bad_module.validate(&env),
+            Err(WormholeError::InvalidGovernanceModule)
+        );
+
+        let bad_action = TransferFeesPayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: 9,
+            chain: CHAIN_ID_STELLAR,
+            amount: 1,
+            recipient: recipient.clone(),
+        };
+        assert_eq!(
+            bad_action.validate(&env),
+            Err(WormholeError::InvalidGovernanceAction)
+        );
+
+        let bad_chain = TransferFeesPayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: ACTION_TRANSFER_FEES,
+            chain: 2,
+            amount: 1,
+            recipient,
+        };
+        assert_eq!(
+            bad_chain.validate(&env),
+            Err(WormholeError::InvalidGovernanceChain)
+        );
+    }
+
+    #[test]
+    fn test_transfer_fees_validate_rejects_when_zero_balance() {
+        let env = Env::default();
+        let (_native_addr, _native_client) = install_native_token_mock(&env);
+        let contract_id = deploy_initialized(&env);
+        let recipient = <Address as TestAddress>::generate(&env);
+        let payload = TransferFeesPayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: ACTION_TRANSFER_FEES,
+            chain: CHAIN_ID_STELLAR,
+            amount: 1,
+            recipient,
+        };
+
+        env.as_contract(&contract_id, || {
+            let res = payload.validate(&env);
+            assert_eq!(res, Err(WormholeError::InsufficientFees));
+        });
+    }
+
+    #[test]
+    fn test_transfer_fees_execute_moves_balance_and_emits_event() {
+        let env = Env::default();
+        env.ledger().set_timestamp(12345);
+        let (_native_addr, native_client) = install_native_token_mock(&env);
+        let contract_id = deploy_initialized(&env);
+        let recipient = <Address as TestAddress>::generate(&env);
+        let payload = TransferFeesPayload {
+            module: BytesN::from_array(&env, &MODULE_CORE),
+            action: ACTION_TRANSFER_FEES,
+            chain: CHAIN_ID_STELLAR,
+            amount: 5 * 10_000_000,
+            recipient: recipient.clone(),
+        };
+        let vaa = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: soroban_sdk::vec![&env],
+            timestamp: 0,
+            nonce: 0,
+            emitter_chain: 1,
+            emitter_address: BytesN::from_array(&env, &[0u8; 32]),
+            sequence: 0,
+            consistency_level: wormhole_soroban_client::ConsistencyLevel::Confirmed,
+            payload: Bytes::new(&env),
+        };
+
+        env.as_contract(&contract_id, || {
+            native_client.set_balance(&contract_id, &(20 * 10_000_000i128));
+            TransferFeesAction::execute(&env, &vaa, &payload).unwrap();
+
+            assert_eq!(native_client.balance(&contract_id), 15 * 10_000_000i128);
+            assert_eq!(native_client.balance(&recipient), 5 * 10_000_000i128);
+        });
+
+        let events = env.events().all().filter_by_contract(&contract_id);
+        let amount_val: Val = (5 * 10_000_000u64).into_val(&env);
+        let recipient_val: Val = recipient.into_val(&env);
+        assert_eq!(
+            events,
+            soroban_sdk::vec![
+                &env,
+                (
+                    contract_id,
+                    soroban_sdk::vec![
+                        &env,
+                        Symbol::new(&env, "wormhole_core").into_val(&env),
+                        Symbol::new(&env, "fee_transfer").into_val(&env),
+                    ],
+                    soroban_sdk::map![
+                        &env,
+                        (Symbol::new(&env, "amount"), amount_val),
+                        (Symbol::new(&env, "recipient"), recipient_val),
+                    ]
+                    .into_val(&env),
+                )
+            ]
+        );
+    }
+}

--- a/stellar/contracts/wormhole-contract/src/initialize.rs
+++ b/stellar/contracts/wormhole-contract/src/initialize.rs
@@ -1,0 +1,186 @@
+//! Contract initialization logic.
+//!
+//! Handles setup of the Wormhole Core contract via the `__constructor` function,
+//! including guardian set creation and governance emitter validation.
+//!
+//! This module is only called by the constructor, which is executed atomically
+//! during deployment (Protocol 22+). The runtime guarantees single execution.
+
+use crate::governance::guardian_set::{set_current_index, store};
+use soroban_sdk::{BytesN, Env, Vec, contractevent};
+use wormhole_soroban_client::*;
+
+/// Emitted once when the contract is successfully initialized.
+///
+/// Guardians and indexers can observe this event to confirm deployment.
+#[contractevent(topics = ["wormhole_core", "init"])]
+struct InitializeEvent {
+    /// Wormhole chain ID for this deployment (61 for Stellar).
+    chain_id: u32,
+    /// Number of guardians in the initial set.
+    guardian_count: u32,
+    /// Chain ID of the governance source (1 for Solana).
+    governance_chain_id: u32,
+    /// Address authorized to emit governance VAAs.
+    governance_emitter: BytesN<32>,
+}
+
+/// Internal initialization logic called by `__constructor`.
+///
+/// Sets up the initial guardian set (index 0) and validates the governance
+/// emitter against the protocol constant.
+///
+/// # Arguments
+/// * `initial_guardians` - Ethereum addresses (20 bytes) of initial guardians
+/// * `governance_emitter` - 32-byte address authorized to emit governance VAAs
+///
+/// # Panics
+/// Panics with `EmptyGuardianSet` if no guardians are provided.
+pub(crate) fn initialize_internal(
+    env: &Env,
+    initial_guardians: Vec<BytesN<20>>,
+    governance_emitter: BytesN<32>,
+) {
+    // Validate initial guardians - panic on failure (constructor semantics)
+    if initial_guardians.is_empty() {
+        env.panic_with_error(WormholeError::EmptyGuardianSet);
+    }
+
+    // Reject deployment with wrong governance emitter
+    if governance_emitter.to_array() != GOVERNANCE_EMITTER {
+        env.panic_with_error(WormholeError::InvalidGovernanceEmitter);
+    }
+
+    // Create the initial guardian set (always index 0)
+    let guardian_set = GuardianSetInfo {
+        keys: initial_guardians.clone(),
+        creation_time: env.ledger().timestamp(),
+    };
+
+    // Panic on storage failure (constructor semantics)
+    if let Err(e) = store(env, 0, guardian_set) {
+        env.panic_with_error(e);
+    }
+
+    set_current_index(env, 0);
+
+    // Emit initialization event
+    InitializeEvent {
+        chain_id: u32::from(CHAIN_ID_STELLAR),
+        guardian_count: initial_guardians.len(),
+        governance_chain_id: GOVERNANCE_CHAIN_ID,
+        governance_emitter: governance_emitter.clone(),
+    }
+    .publish(env);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Wormhole, WormholeClient};
+    use soroban_sdk::{IntoVal, Symbol, Val, map, testutils::Events, vec};
+
+    #[test]
+    fn test_constructor_initializes_state() {
+        let env = Env::default();
+        let guardian = BytesN::from_array(&env, &[0u8; 20]);
+        let initial_guardians = vec![&env, guardian.clone()];
+        let governance_emitter = BytesN::from_array(&env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(
+            Wormhole,
+            (initial_guardians.clone(), governance_emitter.clone()),
+        );
+        let client = WormholeClient::new(&env, &contract_id);
+
+        assert_eq!(client.get_current_guardian_set_index(), 0);
+        assert_eq!(
+            client.get_governance_emitter(),
+            BytesN::from_array(&env, &GOVERNANCE_EMITTER)
+        );
+        let guardian_set = client.get_guardian_set(&0);
+        assert_eq!(guardian_set.keys.len(), 1);
+        assert_eq!(guardian_set.keys.get(0).unwrap(), guardian);
+
+        assert_eq!(guardian_set.creation_time, env.ledger().timestamp());
+    }
+
+    #[test]
+    fn test_constructor_preserves_multiple_guardians_order() {
+        let env = Env::default();
+        let guardian_1 = BytesN::from_array(&env, &[1u8; 20]);
+        let guardian_2 = BytesN::from_array(&env, &[2u8; 20]);
+        let guardian_3 = BytesN::from_array(&env, &[3u8; 20]);
+        let initial_guardians = vec![
+            &env,
+            guardian_1.clone(),
+            guardian_2.clone(),
+            guardian_3.clone(),
+        ];
+        let governance_emitter = BytesN::from_array(&env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter));
+        let client = WormholeClient::new(&env, &contract_id);
+
+        let guardian_set = client.get_guardian_set(&0);
+        assert_eq!(guardian_set.keys.len(), 3);
+        assert_eq!(guardian_set.keys.get(0).unwrap(), guardian_1);
+        assert_eq!(guardian_set.keys.get(1).unwrap(), guardian_2);
+        assert_eq!(guardian_set.keys.get(2).unwrap(), guardian_3);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #35)")]
+    fn test_constructor_rejects_empty_guardians() {
+        let env = Env::default();
+        let initial_guardians: Vec<BytesN<20>> = Vec::new(&env);
+        let governance_emitter = BytesN::from_array(&env, &GOVERNANCE_EMITTER);
+
+        let _ = env.register(Wormhole, (initial_guardians, governance_emitter));
+    }
+
+    #[test]
+    fn test_constructor_emits_single_init_event() {
+        let env = Env::default();
+        let guardian = BytesN::from_array(&env, &[0u8; 20]);
+        let initial_guardians = vec![&env, guardian.clone()];
+        let governance_emitter = BytesN::from_array(&env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter));
+
+        let all_events = env.events().all();
+        let contract_events = all_events.filter_by_contract(&contract_id);
+        assert_eq!(contract_events.events().len(), 1);
+        let chain_id_val: Val = 61u32.into_val(&env);
+        let governance_chain_id_val: Val = 1u32.into_val(&env);
+        let governance_emitter_val: Val =
+            BytesN::from_array(&env, &GOVERNANCE_EMITTER).into_val(&env);
+        let guardian_count_val: Val = 1u32.into_val(&env);
+
+        assert_eq!(
+            contract_events,
+            vec![
+                &env,
+                (
+                    contract_id.clone(),
+                    vec![
+                        &env,
+                        Symbol::new(&env, "wormhole_core").into_val(&env),
+                        Symbol::new(&env, "init").into_val(&env),
+                    ],
+                    map![
+                        &env,
+                        (Symbol::new(&env, "chain_id"), chain_id_val),
+                        (
+                            Symbol::new(&env, "governance_chain_id"),
+                            governance_chain_id_val
+                        ),
+                        (
+                            Symbol::new(&env, "governance_emitter"),
+                            governance_emitter_val
+                        ),
+                        (Symbol::new(&env, "guardian_count"), guardian_count_val)
+                    ]
+                    .into_val(&env),
+                )
+            ]
+        );
+    }
+}

--- a/stellar/contracts/wormhole-contract/src/lib.rs
+++ b/stellar/contracts/wormhole-contract/src/lib.rs
@@ -1,0 +1,341 @@
+//! Wormhole Core Contract implementation for Stellar/Soroban.
+//!
+//! This crate provides the complete implementation of the Wormhole Core
+//! contract, enabling Stellar to participate in Wormhole's cross-chain
+//! messaging protocol as Chain ID 61.
+//!
+//! # Architecture
+//!
+//! - [`Wormhole`] - Main contract struct implementing [`WormholeCoreInterface`]
+//! - [`governance`] - Guardian-signed governance actions (upgrades, fees)
+//! - [`vaa`] - VAA parsing and signature verification
+//! - [`message`] - Cross-chain message posting
+//! - [`storage`] - Persistent storage key definitions
+//! - [`utils`] - Cryptographic and address conversion utilities
+
+#![no_std]
+
+use crate::governance::{
+    ContractUpgradeAction, GovernanceAction, GuardianSetUpgradeAction, SetMessageFeeAction,
+    TransferFeesAction,
+    guardian_set::{get_current_guardian_set_index, get_guardian_set, get_guardian_set_expiry},
+};
+use soroban_sdk::{Address, Bytes, BytesN, Env, Vec, contract, contractimpl};
+use storage::StorageKey;
+use wormhole_soroban_client::{
+    CHAIN_ID_STELLAR, ConsistencyLevel, GOVERNANCE_CHAIN_ID, GOVERNANCE_EMITTER, GuardianSetInfo,
+    STORAGE_TTL_EXTENSION, STORAGE_TTL_THRESHOLD, WormholeCoreInterface, WormholeError,
+    hash_address,
+};
+
+mod governance;
+mod initialize;
+mod message;
+mod storage;
+mod utils;
+mod vaa;
+
+/// Wormhole Core contract for Stellar/Soroban.
+///
+/// Implements the [`WormholeCoreInterface`] trait providing VAA verification,
+/// governance action processing, and cross-chain message posting capabilities.
+#[contract]
+pub struct Wormhole;
+
+/// Constructor and non-trait methods.
+#[contractimpl]
+impl Wormhole {
+    /// Constructor called atomically during contract deployment.
+    ///
+    /// Sets up the initial guardian set (index 0) and stores the governance
+    /// emitter address.
+    ///
+    /// # Arguments
+    /// * `initial_guardians` - Ethereum addresses (20 bytes) of initial
+    ///   guardians
+    /// * `governance_emitter` - 32-byte address authorized to emit governance
+    ///   VAAs
+    ///
+    /// # Panics
+    /// Panics with `EmptyGuardianSet` if no guardians are provided.
+    pub fn __constructor(
+        env: Env,
+        initial_guardians: Vec<BytesN<20>>,
+        governance_emitter: BytesN<32>,
+    ) {
+        initialize::initialize_internal(&env, initial_guardians, governance_emitter);
+    }
+}
+
+/// Implementation of the public Wormhole Core interface.
+#[contractimpl]
+impl WormholeCoreInterface for Wormhole {
+    fn verify_vaa(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
+        vaa::verify_vaa(&env, &vaa_bytes)?;
+        Ok(())
+    }
+
+    fn parse_vaa(
+        env: Env,
+        vaa_bytes: Bytes,
+    ) -> Result<wormhole_soroban_client::VAA, WormholeError> {
+        vaa::parse_vaa(&env, &vaa_bytes)
+    }
+
+    fn parse_and_verify_vaa(
+        env: Env,
+        vaa_bytes: Bytes,
+    ) -> Result<wormhole_soroban_client::VAA, WormholeError> {
+        vaa::parse_and_verify_vaa(&env, &vaa_bytes)
+    }
+
+    fn submit_contract_upgrade(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
+        ContractUpgradeAction::submit(&env, vaa_bytes)
+    }
+
+    fn submit_guardian_set_upgrade(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
+        GuardianSetUpgradeAction::submit(&env, vaa_bytes)
+    }
+
+    fn submit_set_message_fee(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
+        SetMessageFeeAction::submit(&env, vaa_bytes)
+    }
+
+    fn submit_transfer_fees(env: Env, vaa_bytes: Bytes) -> Result<(), WormholeError> {
+        TransferFeesAction::submit(&env, vaa_bytes)
+    }
+
+    fn post_message(
+        env: Env,
+        emitter: Address,
+        nonce: u32,
+        payload: Bytes,
+        consistency_level: ConsistencyLevel,
+    ) -> Result<u64, WormholeError> {
+        emitter.require_auth();
+
+        message::post_message_with_fee(&env, &emitter, nonce, payload, consistency_level)
+    }
+
+    fn get_current_guardian_set_index(env: Env) -> u32 {
+        get_current_guardian_set_index(&env)
+    }
+
+    fn get_guardian_set(env: Env, index: u32) -> Result<GuardianSetInfo, WormholeError> {
+        get_guardian_set(&env, index)
+    }
+
+    fn get_guardian_set_expiry(env: Env, index: u32) -> Option<u64> {
+        get_guardian_set_expiry(&env, index)
+    }
+
+    fn get_emitter_sequence(env: Env, emitter: Address) -> u64 {
+        message::get_emitter_sequence(&env, &emitter)
+    }
+
+    fn get_message_fee(env: Env) -> u64 {
+        governance::get_message_fee(&env)
+    }
+
+    fn is_governance_vaa_consumed(env: Env, vaa_bytes: Bytes) -> Result<bool, WormholeError> {
+        governance::is_governance_vaa_consumed(env, vaa_bytes)
+    }
+
+    fn get_chain_id() -> u32 {
+        u32::from(CHAIN_ID_STELLAR)
+    }
+
+    fn get_governance_chain_id() -> u32 {
+        GOVERNANCE_CHAIN_ID
+    }
+
+    fn get_governance_emitter(env: Env) -> BytesN<32> {
+        BytesN::from_array(&env, &GOVERNANCE_EMITTER)
+    }
+
+    fn record_address(env: Env, address: Address) -> Result<BytesN<32>, WormholeError> {
+        let hash = hash_address(&env, &address);
+        let key = StorageKey::AddressTable(hash.clone());
+        env.storage().persistent().set(&key, &address);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTENSION);
+        Ok(hash)
+    }
+
+    fn get_address_from_hash(env: Env, hash: BytesN<32>) -> Result<Address, WormholeError> {
+        let key = StorageKey::AddressTable(hash);
+        let Some(address) = env.storage().persistent().get(&key) else {
+            return Err(WormholeError::AddressNotFound);
+        };
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTENSION);
+
+        Ok(address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{Bytes, BytesN, Env, testutils::Address as _, vec};
+    use wormhole_soroban_client::{
+        ACTION_GUARDIAN_SET_UPGRADE, ACTION_SET_MESSAGE_FEE, ACTION_TRANSFER_FEES,
+        GOVERNANCE_EMITTER, MODULE_CORE,
+    };
+
+    fn deploy_initialized(env: &Env) -> (Address, WormholeClient<'_>) {
+        let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
+        let initial_guardians = vec![env, guardian];
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter));
+        let client = WormholeClient::new(env, &contract_id);
+        (contract_id, client)
+    }
+
+    fn build_unsigned_governance_vaa(
+        env: &Env,
+        emitter_chain: u16,
+        emitter_address: [u8; 32],
+        action: u8,
+    ) -> Bytes {
+        let mut payload = Bytes::new(env);
+        payload.append(&Bytes::from_array(env, &MODULE_CORE));
+        payload.push_back(action);
+        payload.append(&Bytes::from_slice(env, &CHAIN_ID_STELLAR.to_be_bytes()));
+        payload.append(&Bytes::from_array(env, &[0u8; 64]));
+
+        // VAA bytes (version, guardian_set_index, sig_count=0, then body)
+        let mut vaa = Bytes::new(env);
+        vaa.push_back(1);
+        vaa.append(&Bytes::from_slice(env, &0u32.to_be_bytes()));
+        vaa.push_back(0);
+        vaa.append(&Bytes::from_slice(env, &1u32.to_be_bytes())); // timestamp
+        vaa.append(&Bytes::from_slice(env, &7u32.to_be_bytes())); // nonce
+        vaa.append(&Bytes::from_slice(env, &emitter_chain.to_be_bytes()));
+        vaa.append(&Bytes::from_array(env, &emitter_address));
+        vaa.append(&Bytes::from_slice(env, &1u64.to_be_bytes())); // sequence
+        vaa.push_back(ConsistencyLevel::Confirmed as u8);
+        vaa.append(&payload);
+        vaa
+    }
+
+    #[test]
+    fn test_protocol_constant_getters() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        assert_eq!(client.get_chain_id(), u32::from(CHAIN_ID_STELLAR));
+        assert_eq!(client.get_governance_chain_id(), GOVERNANCE_CHAIN_ID);
+    }
+
+    #[test]
+    fn test_record_address_round_trip() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let address = Address::generate(&env);
+        let hash = hash_address(&env, &address);
+
+        assert_eq!(client.record_address(&address), hash);
+        assert_eq!(client.get_address_from_hash(&hash), address);
+    }
+
+    #[test]
+    fn test_record_account_address_round_trip() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let pk_bytes = BytesN::from_array(&env, &[7u8; 32]);
+        let address = crate::utils::address_from_ed25519_pk_bytes(&env, &pk_bytes);
+        let hash = hash_address(&env, &address);
+
+        assert_eq!(client.record_address(&address), hash);
+        assert_eq!(client.get_address_from_hash(&hash), address);
+    }
+
+    #[test]
+    fn test_get_address_from_hash_returns_not_found_for_missing_hash() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let hash = BytesN::<32>::from_array(&env, &[9u8; 32]);
+
+        assert_eq!(
+            client.try_get_address_from_hash(&hash),
+            Err(Ok(WormholeError::AddressNotFound))
+        );
+    }
+
+    #[test]
+    fn test_get_governance_emitter_returns_const() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let expected = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
+        assert_eq!(client.get_governance_emitter(), expected);
+    }
+
+    #[test]
+    fn test_verify_vaa_wrapper_invalid_format() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let res = client.try_verify_vaa(&Bytes::new(&env));
+        assert_eq!(res, Err(Ok(WormholeError::InvalidVAAFormat)));
+    }
+
+    #[test]
+    fn test_is_governance_vaa_consumed_wrapper_invalid_format() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let res = client.try_is_governance_vaa_consumed(&Bytes::new(&env));
+        assert_eq!(res, Err(Ok(WormholeError::InvalidVAAFormat)));
+    }
+
+    #[test]
+    fn test_submit_set_message_fee_wrapper_invalid_governance_chain() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let vaa =
+            build_unsigned_governance_vaa(&env, 9, GOVERNANCE_EMITTER, ACTION_SET_MESSAGE_FEE);
+        let res = client.try_submit_set_message_fee(&vaa);
+        assert_eq!(res, Err(Ok(WormholeError::InvalidGovernanceChain)));
+    }
+
+    #[test]
+    fn test_submit_guardian_set_upgrade_wrapper_invalid_governance_emitter() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let mut bad_emitter = GOVERNANCE_EMITTER;
+        bad_emitter[31] = 7;
+        let vaa = build_unsigned_governance_vaa(
+            &env,
+            GOVERNANCE_CHAIN_ID as u16,
+            bad_emitter,
+            ACTION_GUARDIAN_SET_UPGRADE,
+        );
+        let res = client.try_submit_guardian_set_upgrade(&vaa);
+        assert_eq!(res, Err(Ok(WormholeError::InvalidGovernanceEmitter)));
+    }
+
+    #[test]
+    fn test_submit_transfer_fees_wrapper_invalid_governance_chain() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let vaa = build_unsigned_governance_vaa(&env, 9, GOVERNANCE_EMITTER, ACTION_TRANSFER_FEES);
+        let res = client.try_submit_transfer_fees(&vaa);
+        assert_eq!(res, Err(Ok(WormholeError::InvalidGovernanceChain)));
+    }
+
+    #[test]
+    fn test_submit_contract_upgrade_wrapper_invalid_format() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        let res = client.try_submit_contract_upgrade(&Bytes::new(&env));
+        assert_eq!(res, Err(Ok(WormholeError::InvalidVAAFormat)));
+    }
+
+    #[test]
+    fn test_guardian_set_expiry_default_none() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        assert_eq!(client.get_guardian_set_expiry(&0), None);
+    }
+}

--- a/stellar/contracts/wormhole-contract/src/message.rs
+++ b/stellar/contracts/wormhole-contract/src/message.rs
@@ -1,0 +1,344 @@
+//! Cross-chain message posting and sequence management.
+//!
+//! Handles posting messages to be attested by Wormhole guardians, including
+//! fee collection, sequence number management, and event emission.
+
+use soroban_sdk::{
+    Address, Bytes, BytesN, Env, address_payload::AddressPayload, contractevent, token,
+};
+use wormhole_soroban_client::{
+    ConsistencyLevel, STORAGE_TTL_EXTENSION, STORAGE_TTL_THRESHOLD, WormholeError,
+};
+
+use crate::{governance, storage::StorageKey, utils::get_native_token_address};
+
+/// Emitted when a cross-chain message is posted successfully.
+///
+/// Guardians observe these events and produce VAAs attesting to the message
+/// contents. The event data matches the message body structure for easy
+/// verification.
+#[contractevent(topics = ["wormhole", "message_published"])]
+struct MessagePublishedEvent {
+    /// Caller-provided nonce for deduplication.
+    nonce: u32,
+    /// Auto-assigned sequence number for this emitter.
+    sequence: u64,
+    /// 32-byte contract ID of the emitter contract.
+    emitter_address: BytesN<32>,
+    /// Application-specific message data.
+    payload: Bytes,
+    /// Requested finality level for attestation.
+    consistency_level: ConsistencyLevel,
+}
+
+/// Returns the next sequence number for an emitter (0 if never used).
+pub fn get_emitter_sequence(env: &Env, emitter: &Address) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::EmitterSequence(emitter.clone()))
+        .unwrap_or(0)
+}
+
+/// Atomically increments and returns the current sequence for an emitter.
+fn next_emitter_sequence(env: &Env, emitter: &Address) -> u64 {
+    let current = get_emitter_sequence(env, emitter);
+    let next = current.saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&StorageKey::EmitterSequence(emitter.clone()), &next);
+
+    env.storage().persistent().extend_ttl(
+        &StorageKey::EmitterSequence(emitter.clone()),
+        STORAGE_TTL_THRESHOLD,
+        STORAGE_TTL_EXTENSION,
+    );
+
+    current
+}
+
+/// Posts a cross-chain message with optional fee collection.
+///
+/// Collects the configured message fee (if any) via `transfer_from`, assigns
+/// a sequence number, then emits a `MessagePublishedEvent` for guardian
+/// observation.
+///
+/// # Errors
+///
+/// - `InsufficientFeePaid` if fee collection fails (requires prior approval)
+pub fn post_message_with_fee(
+    env: &Env,
+    emitter: &Address,
+    nonce: u32,
+    payload: Bytes,
+    consistency_level: ConsistencyLevel,
+) -> Result<u64, WormholeError> {
+    let required_fee = governance::get_message_fee(env);
+
+    if required_fee > 0 {
+        env.storage().persistent().extend_ttl(
+            &StorageKey::MessageFee,
+            STORAGE_TTL_THRESHOLD,
+            STORAGE_TTL_EXTENSION,
+        );
+
+        let native_token = get_native_token_address(env);
+        let token_client = token::TokenClient::new(env, &native_token);
+        let contract = env.current_contract_address();
+
+        match token_client.try_transfer_from(
+            &contract,
+            emitter,
+            &contract,
+            &i128::from(required_fee),
+        ) {
+            Ok(Ok(())) => {}
+            _ => {
+                return Err(WormholeError::InsufficientFeePaid);
+            }
+        }
+    }
+
+    let sequence = next_emitter_sequence(env, emitter);
+
+    let emitter_bytes = match emitter.to_payload() {
+        Some(AddressPayload::ContractIdHash(contract_id)) => contract_id,
+        _ => return Err(WormholeError::InvalidEmitterAddress),
+    };
+
+    MessagePublishedEvent {
+        nonce,
+        sequence,
+        emitter_address: emitter_bytes,
+        payload,
+        consistency_level,
+    }
+    .publish(env);
+
+    Ok(sequence)
+}
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{
+        Address, Bytes, BytesN, IntoVal, Symbol, Val,
+        address_payload::AddressPayload,
+        map,
+        testutils::{Address as TestAddress, Events},
+        vec,
+    };
+
+    use super::*;
+    use crate::{Wormhole, WormholeClient};
+    use wormhole_soroban_client::GOVERNANCE_EMITTER;
+
+    fn deploy_initialized(env: &Env) -> (Address, WormholeClient<'_>) {
+        let guardian = BytesN::from_array(env, &[0u8; 20]);
+        let initial_guardians = vec![env, guardian];
+        let governance_emitter = BytesN::from_array(env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(Wormhole, (initial_guardians, governance_emitter));
+        let client = WormholeClient::new(env, &contract_id);
+        (contract_id, client)
+    }
+
+    fn address_to_bytes32(emitter: &Address) -> BytesN<32> {
+        match emitter.to_payload() {
+            Some(AddressPayload::ContractIdHash(contract_id)) => contract_id,
+            _ => panic!("expected contract emitter address"),
+        }
+    }
+
+    fn runtime_test_nonce(env: &Env) -> u32 {
+        u32::try_from(env.ledger().timestamp()).unwrap_or_default()
+    }
+
+    #[test]
+    fn test_post_message_accepts_generated_contract_emitter() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        env.mock_all_auths();
+
+        let emitter = <Address as TestAddress>::generate(&env);
+        let nonce = runtime_test_nonce(&env);
+        let res = client.try_post_message(
+            &emitter,
+            &nonce,
+            &Bytes::from_array(&env, &[0xAA]),
+            &ConsistencyLevel::Confirmed,
+        );
+        assert_eq!(res, Ok(Ok(0)));
+    }
+
+    #[test]
+    fn test_post_message_rejects_ed25519_account() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+        env.mock_all_auths();
+
+        let pk_bytes = BytesN::from_array(&env, &[8u8; 32]);
+        let emitter = crate::utils::address_from_ed25519_pk_bytes(&env, &pk_bytes);
+        let nonce = runtime_test_nonce(&env);
+
+        let res = client.try_post_message(
+            &emitter,
+            &nonce,
+            &Bytes::from_array(&env, &[0xAA]),
+            &ConsistencyLevel::Confirmed,
+        );
+        assert_eq!(res, Err(Ok(WormholeError::InvalidEmitterAddress)));
+    }
+
+    #[test]
+    fn test_post_message_no_fee() {
+        let env = Env::default();
+        let (contract_id, client) = deploy_initialized(&env);
+        assert_eq!(client.get_message_fee(), 0);
+
+        env.mock_all_auths();
+
+        let emitter = contract_id.clone();
+        let nonce = runtime_test_nonce(&env);
+        let payload = Bytes::from_array(&env, &[0xAA, 0xBB, 0xCC]);
+        let cl = ConsistencyLevel::Confirmed;
+
+        let seq0 = client.post_message(&emitter, &nonce, &payload, &cl);
+        assert_eq!(seq0, 0);
+
+        let events = env.events().all().filter_by_contract(&contract_id);
+        assert_eq!(events.events().len(), 1);
+        assert_eq!(client.get_emitter_sequence(&emitter), 1);
+
+        let seq1 = client.post_message(&emitter, &nonce, &payload, &cl);
+        assert_eq!(seq1, 1);
+        assert_eq!(client.get_emitter_sequence(&emitter), 2);
+    }
+
+    #[test]
+    fn test_post_message_emits_event_payload() {
+        let env = Env::default();
+        let (contract_id, client) = deploy_initialized(&env);
+        env.mock_all_auths();
+
+        let emitter = contract_id.clone();
+        let emitter_bytes32 = address_to_bytes32(&emitter);
+        let nonce = runtime_test_nonce(&env);
+        let payload = Bytes::from_array(&env, &[0xAB, 0xCD]);
+        let cl = ConsistencyLevel::Confirmed;
+
+        let seq = client.post_message(&emitter, &nonce, &payload, &cl);
+        assert_eq!(seq, 0);
+
+        let all_events = env.events().all();
+        let contract_events = all_events.filter_by_contract(&contract_id);
+        assert_eq!(contract_events.events().len(), 1);
+
+        let consistency_level_val: Val = cl.into_val(&env);
+        let emitter_val: Val = emitter_bytes32.into_val(&env);
+        let nonce_val: Val = nonce.into_val(&env);
+        let payload_val: Val = payload.clone().into_val(&env);
+        let sequence_val: Val = 0u64.into_val(&env);
+
+        assert_eq!(
+            contract_events,
+            vec![
+                &env,
+                (
+                    contract_id.clone(),
+                    vec![
+                        &env,
+                        Symbol::new(&env, "wormhole").into_val(&env),
+                        Symbol::new(&env, "message_published").into_val(&env),
+                    ],
+                    map![
+                        &env,
+                        (
+                            Symbol::new(&env, "consistency_level"),
+                            consistency_level_val
+                        ),
+                        (Symbol::new(&env, "emitter_address"), emitter_val),
+                        (Symbol::new(&env, "nonce"), nonce_val),
+                        (Symbol::new(&env, "payload"), payload_val),
+                        (Symbol::new(&env, "sequence"), sequence_val)
+                    ]
+                    .into_val(&env),
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn test_post_message_nonzero_fee_failure_does_not_mutate_state() {
+        let env = Env::default();
+        let (contract_id, client) = deploy_initialized(&env);
+        env.mock_all_auths();
+
+        let fee: u64 = 1;
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&StorageKey::MessageFee, &fee);
+        });
+        assert_eq!(client.get_message_fee(), fee);
+
+        let emitter = contract_id.clone();
+        let nonce = runtime_test_nonce(&env);
+        let res = client.try_post_message(
+            &emitter,
+            &nonce,
+            &Bytes::from_array(&env, &[0x01]),
+            &ConsistencyLevel::Confirmed,
+        );
+        assert_eq!(res, Err(Ok(WormholeError::InsufficientFeePaid)));
+        assert_eq!(client.get_emitter_sequence(&emitter), 0);
+    }
+
+    #[test]
+    fn test_post_message_fee_not_paid() {
+        let env = Env::default();
+        let (contract_id, client) = deploy_initialized(&env);
+
+        let fee: u64 = 10_000;
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&StorageKey::MessageFee, &fee);
+        });
+        assert_eq!(client.get_message_fee(), fee);
+
+        env.mock_all_auths();
+
+        let emitter = <Address as TestAddress>::generate(&env);
+        let nonce = runtime_test_nonce(&env);
+        let payload = Bytes::from_array(&env, &[0x01, 0x02, 0x03]);
+        let cl = ConsistencyLevel::Confirmed;
+
+        let res = client.try_post_message(&emitter, &nonce, &payload, &cl);
+        assert_eq!(res, Err(Ok(WormholeError::InsufficientFeePaid)));
+
+        let events = env.events().all().filter_by_contract(&contract_id);
+        assert_eq!(events.events().len(), 0);
+    }
+
+    #[test]
+    fn test_emitter_sequence_increment() {
+        let env = Env::default();
+        let (contract_id, client) = deploy_initialized(&env);
+        env.mock_all_auths();
+
+        let emitter = contract_id.clone();
+        let nonce = runtime_test_nonce(&env);
+        let payload = Bytes::from_array(&env, &[0xDE, 0xAD, 0xBE, 0xEF]);
+        let cl = ConsistencyLevel::Confirmed;
+
+        let s0 = client.post_message(&emitter, &nonce, &payload, &cl);
+        assert_eq!(s0, 0);
+        assert_eq!(client.get_emitter_sequence(&emitter), 1);
+
+        let s1 = client.post_message(&emitter, &nonce, &payload, &cl);
+        assert_eq!(s1, 1);
+        assert_eq!(client.get_emitter_sequence(&emitter), 2);
+
+        let s2 = client.post_message(&emitter, &nonce, &payload, &cl);
+        assert_eq!(s2, 2);
+        assert_eq!(client.get_emitter_sequence(&emitter), 3);
+    }
+}

--- a/stellar/contracts/wormhole-contract/src/storage.rs
+++ b/stellar/contracts/wormhole-contract/src/storage.rs
@@ -1,0 +1,31 @@
+//! Persistent storage key definitions for the Wormhole Core contract.
+//!
+//! All contract state is stored under these keys. Keys are extended
+//! automatically on access to maintain TTL (see `STORAGE_TTL_THRESHOLD` and
+//! `STORAGE_TTL_EXTENSION`).
+
+use soroban_sdk::{Address, BytesN, contracttype};
+
+/// Storage key enum for all persistent contract state.
+///
+/// Uses Soroban's `contracttype` for efficient serialization. Keys with
+/// parameters (e.g., `GuardianSet(u32)`) create separate storage entries per
+/// value.
+#[derive(Clone)]
+#[contracttype]
+pub enum StorageKey {
+    /// Index of the currently active guardian set (starts at 0).
+    CurrentGuardianSetIndex,
+    /// Guardian set data keyed by index; stores `GuardianSetInfo`.
+    GuardianSet(u32),
+    /// Unix timestamp when a guardian set expires (24h after replacement).
+    GuardianSetExpiry(u32),
+    /// Tracks consumed governance VAA hashes for replay protection.
+    ConsumedGovernanceVAA(BytesN<32>),
+    /// Fee charged per message in stroops (10^-7 XLM).
+    MessageFee,
+    /// Next sequence number for each emitter address.
+    EmitterSequence(Address),
+    /// Hash of an address used in `from/to` fields.
+    AddressTable(BytesN<32>),
+}

--- a/stellar/contracts/wormhole-contract/src/utils/mod.rs
+++ b/stellar/contracts/wormhole-contract/src/utils/mod.rs
@@ -1,0 +1,45 @@
+//! Cryptographic and address conversion utilities.
+//!
+//! Provides helper functions for hashing, address format conversion between
+//! Stellar and Ethereum/Wormhole formats, and token address resolution.
+
+use soroban_sdk::{Address, Bytes, BytesN, Env, String, address_payload::AddressPayload};
+use wormhole_soroban_client::NATIVE_TOKEN_ADDRESS;
+
+/// Computes keccak256 hash of data, returning a 32-byte array.
+pub fn keccak256_hash(env: &Env, data: &Bytes) -> BytesN<32> {
+    env.crypto().keccak256(data).to_bytes()
+}
+
+/// Converts a 32-byte ED25519 public key to a Stellar `Address`.
+///
+/// Used for decoding fee transfer recipients from governance VAA payloads.
+pub fn address_from_ed25519_pk_bytes(env: &Env, pk_bytes: &BytesN<32>) -> Address {
+    Address::from_payload(
+        env,
+        AddressPayload::AccountIdPublicKeyEd25519(pk_bytes.clone()),
+    )
+}
+
+/// Derives an Ethereum address from a recovered secp256k1 public key.
+///
+/// Strips the 0x04 prefix, hashes the remaining 64 bytes with keccak256,
+/// and takes the last 20 bytes as the Ethereum address.
+pub fn pubkey_to_eth_address(env: &Env, pubkey: &BytesN<65>) -> BytesN<20> {
+    let pubkey_array = pubkey.to_array();
+    let pubkey_bytes = Bytes::from_array(env, &pubkey_array);
+    let pubkey_without_prefix = pubkey_bytes.slice(1..);
+
+    let hash = env.crypto().keccak256(&pubkey_without_prefix);
+
+    let hash_array = hash.to_array();
+    let mut addr_bytes = [0u8; 20];
+    addr_bytes.copy_from_slice(&hash_array[12..32]);
+
+    BytesN::from_array(env, &addr_bytes)
+}
+
+/// Returns the native XLM Stellar Asset Contract address.
+pub fn get_native_token_address(env: &Env) -> Address {
+    Address::from_string(&String::from_str(env, NATIVE_TOKEN_ADDRESS))
+}

--- a/stellar/contracts/wormhole-contract/src/vaa.rs
+++ b/stellar/contracts/wormhole-contract/src/vaa.rs
@@ -1,0 +1,557 @@
+//! VAA verification and signature validation.
+//!
+//! Provides cryptographic verification of VAA signatures against stored
+//! guardian sets. Uses secp256k1 ECDSA recovery to derive Ethereum addresses
+//! from signatures, then compares against the known guardian keys.
+//!
+//! Parsing and serialization are in `wormhole-soroban-client::types`.
+
+pub use wormhole_soroban_client::{Signature, VAA};
+
+use crate::governance;
+use soroban_sdk::{Bytes, BytesN, Env, Vec};
+use wormhole_soroban_client::WormholeError;
+
+/// Verifies all VAA signatures against the stored guardian set.
+///
+/// Validates guardian set existence and expiry, then checks that:
+/// - At least quorum signatures are present (13/19 for mainnet)
+/// - Signature indices are strictly ascending (prevents reuse)
+/// - Each signature recovers to the expected guardian's Ethereum address
+///
+/// Uses double keccak256 hashing as per Wormhole spec:
+/// `keccak256(keccak256(body))`.
+pub fn verify_vaa_signatures(vaa: &VAA, env: &Env) -> Result<bool, WormholeError> {
+    let body_bytes = vaa.serialize_body(env);
+
+    let guardian_set_info =
+        governance::guardian_set::get_guardian_set(env, vaa.guardian_set_index)?;
+
+    if let Some(expiry) =
+        governance::guardian_set::get_guardian_set_expiry(env, vaa.guardian_set_index)
+        && env.ledger().timestamp() > expiry
+    {
+        return Err(WormholeError::GuardianSetExpired);
+    }
+
+    verify_signatures_impl(vaa, env, &body_bytes, &guardian_set_info.keys)
+}
+
+/// Verifies a single ECDSA signature matches an expected Ethereum address.
+///
+/// Recovers the secp256k1 public key from the signature and message hash,
+/// derives the Ethereum address (last 20 bytes of keccak256(pubkey[1..])),
+/// and compares against the expected guardian address.
+pub fn verify_signature(
+    sig: &Signature,
+    env: &Env,
+    message_hash: &soroban_sdk::crypto::Hash<32>,
+    expected_address: &BytesN<20>,
+) -> Result<bool, WormholeError> {
+    let mut sig_bytes = [0u8; 64];
+    let r_array = sig.r.to_array();
+    let s_array = sig.s.to_array();
+    sig_bytes[..32].copy_from_slice(&r_array);
+    sig_bytes[32..].copy_from_slice(&s_array);
+    let sig_formatted = BytesN::<64>::from_array(env, &sig_bytes);
+
+    let recovered_pubkey = env
+        .crypto()
+        .secp256k1_recover(message_hash, &sig_formatted, sig.v);
+
+    let eth_address = crate::utils::pubkey_to_eth_address(env, &recovered_pubkey);
+
+    Ok(&eth_address == expected_address)
+}
+
+/// Calculates required quorum: `(n * 2 / 3) + 1` (e.g., 13 of 19 guardians).
+fn calculate_quorum(num_guardians: u32) -> u32 {
+    num_guardians
+        .saturating_mul(2)
+        .saturating_div(3)
+        .saturating_add(1)
+}
+
+/// Verifies all signatures against a guardian key set using double keccak256.
+fn verify_signatures_impl(
+    vaa: &VAA,
+    env: &Env,
+    body_bytes: &Bytes,
+    guardian_keys: &Vec<BytesN<20>>,
+) -> Result<bool, WormholeError> {
+    let guardian_count = guardian_keys.len();
+    if guardian_count == 0 {
+        return Err(WormholeError::InvalidGuardianSetIndex);
+    }
+
+    let required_sigs = calculate_quorum(guardian_count);
+    if vaa.signatures.len() < required_sigs {
+        return Err(WormholeError::InsufficientSignatures);
+    }
+
+    let body_hash_bytes: Bytes = crate::utils::keccak256_hash(env, body_bytes).into();
+    let double_hash = env.crypto().keccak256(&body_hash_bytes);
+
+    let mut last_guardian_index = None;
+
+    for signature in vaa.signatures.iter() {
+        if let Some(last_idx) = last_guardian_index
+            && signature.guardian_index <= last_idx
+        {
+            return Err(WormholeError::SignaturesNotAscending);
+        }
+        last_guardian_index = Some(signature.guardian_index);
+
+        if signature.guardian_index >= guardian_count {
+            return Err(WormholeError::GuardianIndexOutOfBounds);
+        }
+
+        let guardian_key = guardian_keys
+            .get(signature.guardian_index)
+            .ok_or(WormholeError::GuardianIndexOutOfBounds)?;
+
+        if !verify_signature(&signature, env, &double_hash, &guardian_key)? {
+            return Err(WormholeError::InvalidSignature);
+        }
+    }
+
+    Ok(true)
+}
+
+/// Parses a VAA and verifies all guardian signatures in a single call.
+///
+/// This is the primary entry point for external integrators who need both
+/// parsing and verification. Avoids the double parse that occurs when
+/// calling `verify_vaa` and `parse_vaa` separately.
+pub fn parse_and_verify_vaa(env: &Env, vaa_bytes: &Bytes) -> Result<VAA, WormholeError> {
+    let vaa = VAA::try_from((env, vaa_bytes))?;
+    verify_vaa_signatures(&vaa, env)?;
+    Ok(vaa)
+}
+
+/// Verifies a VAA's guardian signatures, returning success or an error.
+///
+/// Parses and verifies internally. For callers that also need the parsed
+/// VAA, use [`parse_and_verify_vaa`] instead to avoid a double parse.
+pub fn verify_vaa(env: &Env, vaa_bytes: &Bytes) -> Result<(), WormholeError> {
+    parse_and_verify_vaa(env, vaa_bytes)?;
+    Ok(())
+}
+
+/// Parses VAA bytes into a structured `VAA` without signature verification.
+pub fn parse_vaa(env: &Env, vaa_bytes: &Bytes) -> Result<VAA, WormholeError> {
+    VAA::try_from((env, vaa_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Ledger, vec};
+    use wormhole_soroban_client::{ConsistencyLevel, GOVERNANCE_EMITTER};
+
+    fn deploy_initialized(env: &Env) -> (soroban_sdk::Address, crate::WormholeClient<'_>) {
+        let guardian = BytesN::<20>::from_array(env, &[0u8; 20]);
+        let initial_guardians = vec![env, guardian];
+        let governance_emitter = BytesN::<32>::from_array(env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
+        let client = crate::WormholeClient::new(env, &contract_id);
+        (contract_id, client)
+    }
+
+    fn base_vaa_with_guardian_set(env: &Env, guardian_set_index: u32) -> VAA {
+        VAA {
+            version: 1,
+            guardian_set_index,
+            signatures: Vec::new(env),
+            timestamp: 0x01020304,
+            nonce: 0xA0B0C0D0,
+            emitter_chain: 61,
+            emitter_address: BytesN::<32>::from_array(env, &[0x33u8; 32]),
+            sequence: 7,
+            consistency_level: ConsistencyLevel::Confirmed,
+            payload: Bytes::from_slice(env, &[0xAA, 0xBB]),
+        }
+    }
+
+    fn sign_for_vaa(
+        env: &Env,
+        vaa: &VAA,
+        sk_bytes: [u8; 32],
+        guardian_index: u32,
+    ) -> (Signature, BytesN<20>) {
+        let body_bytes = vaa.serialize_body(env);
+        let body_hash_bytes: Bytes = crate::utils::keccak256_hash(env, &body_bytes).into();
+        let double_hash = env.crypto().keccak256(&body_hash_bytes);
+        let msg32: [u8; 32] = double_hash.to_array();
+
+        let secp = secp256k1::Secp256k1::new();
+        let sk = secp256k1::SecretKey::from_byte_array(sk_bytes).unwrap();
+        let pk = secp256k1::PublicKey::from_secret_key(&secp, &sk);
+        let pk_bytes65 = BytesN::<65>::from_array(env, &pk.serialize_uncompressed());
+        let guardian_eth = crate::utils::pubkey_to_eth_address(env, &pk_bytes65);
+
+        let message = secp256k1::Message::from_digest(msg32);
+        let sig = secp.sign_ecdsa_recoverable(message, &sk);
+        let (recid, compact64) = sig.serialize_compact();
+
+        let mut r_arr = [0u8; 32];
+        let mut s_arr = [0u8; 32];
+        r_arr.copy_from_slice(&compact64[0..32]);
+        s_arr.copy_from_slice(&compact64[32..64]);
+
+        (
+            Signature {
+                guardian_index,
+                r: BytesN::<32>::from_array(env, &r_arr),
+                s: BytesN::<32>::from_array(env, &s_arr),
+                v: i32::from(recid) as u32,
+            },
+            guardian_eth,
+        )
+    }
+
+    #[test]
+    fn test_parse_vaa_valid() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+
+        // Known fields
+        let version_u8: u8 = 1;
+        let guardian_set_index: u32 = 5;
+        let num_signatures_u8: u8 = 0;
+
+        let timestamp: u32 = 0x01020304;
+        let nonce: u32 = 0xA0B0C0D0;
+        let emitter_chain_u16: u16 = 61;
+        let emitter_address_arr: [u8; 32] = [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
+            0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B,
+            0x1C, 0x1D, 0x1E, 0x1F,
+        ];
+        let sequence: u64 = 0x0102030405060708;
+        let consistency_level_u8: u8 = ConsistencyLevel::Confirmed as u8;
+        let payload: [u8; 2] = [0xAA, 0xBB];
+
+        let mut raw = Bytes::new(&env);
+
+        raw.append(&Bytes::from_slice(&env, &[version_u8]));
+        raw.append(&Bytes::from_slice(&env, &guardian_set_index.to_be_bytes()));
+        raw.append(&Bytes::from_slice(&env, &[num_signatures_u8]));
+        // signatures: none
+
+        raw.append(&Bytes::from_slice(&env, &timestamp.to_be_bytes()));
+        raw.append(&Bytes::from_slice(&env, &nonce.to_be_bytes()));
+        raw.append(&Bytes::from_slice(&env, &emitter_chain_u16.to_be_bytes()));
+        raw.append(&Bytes::from_slice(&env, &emitter_address_arr));
+        raw.append(&Bytes::from_slice(&env, &sequence.to_be_bytes()));
+        raw.append(&Bytes::from_slice(&env, &[consistency_level_u8]));
+        raw.append(&Bytes::from_slice(&env, &payload));
+
+        let vaa = client.parse_vaa(&raw);
+
+        assert_eq!(vaa.version, u32::from(version_u8));
+        assert_eq!(vaa.guardian_set_index, guardian_set_index);
+        assert_eq!(vaa.signatures.len(), 0);
+
+        assert_eq!(vaa.timestamp, timestamp);
+        assert_eq!(vaa.nonce, nonce);
+        assert_eq!(vaa.emitter_chain, u32::from(emitter_chain_u16));
+
+        let expected_emitter_address = BytesN::<32>::from_array(&env, &emitter_address_arr);
+        assert_eq!(vaa.emitter_address, expected_emitter_address);
+
+        assert_eq!(vaa.sequence, sequence);
+        assert_eq!(vaa.consistency_level, ConsistencyLevel::Confirmed);
+
+        let expected_payload = Bytes::from_slice(&env, &payload);
+        assert_eq!(vaa.payload, expected_payload);
+    }
+
+    #[test]
+    fn test_parse_vaa_invalid_format() {
+        let env = Env::default();
+        let (_contract_id, client) = deploy_initialized(&env);
+
+        let b0 = Bytes::new(&env);
+        let r0 = client.try_parse_vaa(&b0);
+        assert_eq!(r0, Err(Ok(WormholeError::InvalidVAAFormat)));
+
+        let b1 = Bytes::from_slice(&env, &[0u8; 56]);
+        let r1 = client.try_parse_vaa(&b1);
+        assert_eq!(r1, Err(Ok(WormholeError::InvalidVAAFormat)));
+
+        let mut b2 = Bytes::new(&env);
+
+        // header
+        b2.append(&Bytes::from_slice(&env, &[1u8])); // version
+        b2.append(&Bytes::from_slice(&env, &0u32.to_be_bytes())); // guardian_set_index
+        b2.append(&Bytes::from_slice(&env, &[1u8])); // num_signatures = 1
+
+        // body (51 bytes), payload empty
+        b2.append(&Bytes::from_slice(&env, &0u32.to_be_bytes())); // timestamp
+        b2.append(&Bytes::from_slice(&env, &0u32.to_be_bytes())); // nonce
+        b2.append(&Bytes::from_slice(&env, &0u16.to_be_bytes())); // emitter_chain
+        b2.append(&Bytes::from_slice(&env, &[0u8; 32])); // emitter_address
+        b2.append(&Bytes::from_slice(&env, &0u64.to_be_bytes())); // sequence
+        b2.append(&Bytes::from_slice(&env, &[0u8])); // consistency_level
+
+        let r2 = client.try_parse_vaa(&b2);
+        assert_eq!(r2, Err(Ok(WormholeError::InvalidVAAFormat)));
+    }
+
+    #[test]
+    fn test_get_body_bytes_function() {
+        let env = Env::default();
+
+        let mut raw = Bytes::new(&env);
+
+        // header (6 bytes)
+        raw.append(&Bytes::from_slice(&env, &[1u8])); // version
+        raw.append(&Bytes::from_slice(&env, &5u32.to_be_bytes())); // guardian_set_index
+        raw.append(&Bytes::from_slice(&env, &[0u8])); // sig_count = 0
+
+        // body (51 + payload)
+        raw.append(&Bytes::from_slice(&env, &0x01020304u32.to_be_bytes())); // timestamp
+        raw.append(&Bytes::from_slice(&env, &0xA0B0C0D0u32.to_be_bytes())); // nonce
+        raw.append(&Bytes::from_slice(&env, &61u16.to_be_bytes())); // emitter_chain
+        raw.append(&Bytes::from_slice(&env, &[0x11u8; 32])); // emitter_address
+        raw.append(&Bytes::from_slice(
+            &env,
+            &0x0102030405060708u64.to_be_bytes(),
+        )); // sequence
+        raw.append(&Bytes::from_slice(
+            &env,
+            &[ConsistencyLevel::Confirmed as u8],
+        ));
+        raw.append(&Bytes::from_slice(&env, &[0xAAu8, 0xBBu8, 0xCCu8])); // payload
+
+        let body = VAA::get_body_bytes(&raw).expect("expected valid body bytes");
+
+        let mut expected_body = Bytes::new(&env);
+        expected_body.append(&Bytes::from_slice(&env, &0x01020304u32.to_be_bytes())); // timestamp
+        expected_body.append(&Bytes::from_slice(&env, &0xA0B0C0D0u32.to_be_bytes())); // nonce
+        expected_body.append(&Bytes::from_slice(&env, &61u16.to_be_bytes())); // emitter_chain
+        expected_body.append(&Bytes::from_slice(&env, &[0x11u8; 32])); // emitter_address
+        expected_body.append(&Bytes::from_slice(
+            &env,
+            &0x0102030405060708u64.to_be_bytes(),
+        )); // sequence
+        expected_body.append(&Bytes::from_slice(
+            &env,
+            &[ConsistencyLevel::Confirmed as u8],
+        ));
+        expected_body.append(&Bytes::from_slice(&env, &[0xAAu8, 0xBBu8, 0xCCu8])); // payload
+
+        assert_eq!(body, expected_body);
+
+        let too_short = Bytes::from_slice(&env, &[1u8, 2u8, 3u8, 4u8, 5u8]);
+        let r0 = VAA::get_body_bytes(&too_short);
+        assert_eq!(r0, Err(WormholeError::InvalidVAAFormat));
+
+        let mut corrupt = Bytes::new(&env);
+
+        corrupt.append(&Bytes::from_slice(&env, &[1u8]));
+        corrupt.append(&Bytes::from_slice(&env, &0u32.to_be_bytes()));
+        corrupt.append(&Bytes::from_slice(&env, &[1u8]));
+
+        // body (51 bytes), payload empty
+        corrupt.append(&Bytes::from_slice(&env, &0u32.to_be_bytes())); // timestamp
+        corrupt.append(&Bytes::from_slice(&env, &0u32.to_be_bytes())); // nonce
+        corrupt.append(&Bytes::from_slice(&env, &0u16.to_be_bytes())); // emitter_chain
+        corrupt.append(&Bytes::from_slice(&env, &[0u8; 32])); // emitter_address
+        corrupt.append(&Bytes::from_slice(&env, &0u64.to_be_bytes())); // sequence
+        corrupt.append(&Bytes::from_slice(&env, &[0u8])); // consistency_level
+
+        let r1 = VAA::get_body_bytes(&corrupt);
+        assert_eq!(r1, Err(WormholeError::InvalidVAAFormat));
+    }
+
+    #[test]
+    fn test_verify_vaa_insufficient_sigs() {
+        let env = Env::default();
+        let governance_emitter = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
+
+        let g0 = BytesN::<20>::from_array(&env, &[0u8; 20]);
+        let g1 = BytesN::<20>::from_array(&env, &[1u8; 20]);
+        let g2 = BytesN::<20>::from_array(&env, &[2u8; 20]);
+        let initial_guardians = vec![&env, g0, g1, g2];
+        let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
+
+        let mut sigs = Vec::<Signature>::new(&env);
+        sigs.push_back(Signature {
+            guardian_index: 0,
+            r: BytesN::<32>::from_array(&env, &[0u8; 32]),
+            s: BytesN::<32>::from_array(&env, &[0u8; 32]),
+            v: 0,
+        });
+
+        let vaa = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: sigs,
+            timestamp: 0,
+            nonce: 0,
+            emitter_chain: 61,
+            emitter_address: BytesN::<32>::from_array(&env, &[0x11u8; 32]),
+            sequence: 0,
+            consistency_level: ConsistencyLevel::Confirmed,
+            payload: Bytes::from_slice(&env, &[0xAA, 0xBB]),
+        };
+
+        let res = env.as_contract(&contract_id, || verify_vaa_signatures(&vaa, &env));
+        assert_eq!(res, Err(WormholeError::InsufficientSignatures));
+    }
+
+    #[test]
+    fn test_verify_vaa_invalid_signature() {
+        let env = Env::default();
+        let stored_guardian = BytesN::<20>::from_array(&env, &[0x11u8; 20]);
+        let initial_guardians = soroban_sdk::vec![&env, stored_guardian];
+        let governance_emitter = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
+
+        let base_vaa = VAA {
+            version: 1,
+            guardian_set_index: 0,
+            signatures: Vec::new(&env),
+            timestamp: 0x01020304,
+            nonce: 0xA0B0C0D0,
+            emitter_chain: 61,
+            emitter_address: BytesN::<32>::from_array(&env, &[0x33u8; 32]),
+            sequence: 7,
+            consistency_level: ConsistencyLevel::Confirmed,
+            payload: Bytes::from_slice(&env, &[0xAA, 0xBB]),
+        };
+
+        let body_bytes = base_vaa.serialize_body(&env);
+        let body_hash_bytes: Bytes = crate::utils::keccak256_hash(&env, &body_bytes).into();
+        let double_hash = env.crypto().keccak256(&body_hash_bytes);
+        let msg32: [u8; 32] = double_hash.to_array();
+
+        let secp = secp256k1::Secp256k1::new();
+
+        let sk = secp256k1::SecretKey::from_byte_array([0x42u8; 32]).unwrap();
+
+        let message = secp256k1::Message::from_digest(msg32);
+
+        let sig = secp.sign_ecdsa_recoverable(message, &sk);
+        let (recid, compact64) = sig.serialize_compact();
+
+        let mut r_arr = [0u8; 32];
+        let mut s_arr = [0u8; 32];
+        r_arr.copy_from_slice(&compact64[0..32]);
+        s_arr.copy_from_slice(&compact64[32..64]);
+
+        let sig_entry = Signature {
+            guardian_index: 0,
+            r: BytesN::<32>::from_array(&env, &r_arr),
+            s: BytesN::<32>::from_array(&env, &s_arr),
+            v: i32::from(recid) as u32,
+        };
+
+        let mut sigs = Vec::new(&env);
+        sigs.push_back(sig_entry);
+
+        let mut vaa = base_vaa.clone();
+        vaa.signatures = sigs;
+
+        env.as_contract(&contract_id, || {
+            let res = verify_vaa_signatures(&vaa, &env);
+            assert_eq!(res, Err(WormholeError::InvalidSignature));
+        });
+    }
+
+    #[test]
+    fn test_verify_vaa_valid_signatures() {
+        let env = Env::default();
+        let base_vaa = base_vaa_with_guardian_set(&env, 0);
+        let (sig_entry, valid_eth_address) = sign_for_vaa(&env, &base_vaa, [0x55u8; 32], 0);
+
+        let mut sigs = Vec::new(&env);
+        sigs.push_back(sig_entry);
+
+        let mut vaa = base_vaa.clone();
+        vaa.signatures = sigs;
+
+        let initial_guardians = soroban_sdk::vec![&env, valid_eth_address];
+        let governance_emitter = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
+
+        env.as_contract(&contract_id, || {
+            let res = verify_vaa_signatures(&vaa, &env);
+            assert_eq!(res, Ok(true));
+        });
+    }
+
+    #[test]
+    fn test_verify_vaa_guardian_set_not_found() {
+        let env = Env::default();
+        let (contract_id, _client) = deploy_initialized(&env);
+        let vaa = base_vaa_with_guardian_set(&env, 42);
+
+        env.as_contract(&contract_id, || {
+            let res = verify_vaa_signatures(&vaa, &env);
+            assert_eq!(res, Err(WormholeError::GuardianSetNotFound));
+        });
+    }
+
+    #[test]
+    fn test_verify_vaa_guardian_set_expired() {
+        let env = Env::default();
+        let (contract_id, _client) = deploy_initialized(&env);
+        env.ledger().set_timestamp(1);
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&crate::storage::StorageKey::GuardianSetExpiry(0), &0u64);
+        });
+
+        let vaa = base_vaa_with_guardian_set(&env, 0);
+        env.as_contract(&contract_id, || {
+            let res = verify_vaa_signatures(&vaa, &env);
+            assert_eq!(res, Err(WormholeError::GuardianSetExpired));
+        });
+    }
+
+    #[test]
+    fn test_verify_vaa_guardian_index_out_of_bounds() {
+        let env = Env::default();
+        let (contract_id, _client) = deploy_initialized(&env);
+
+        let mut vaa = base_vaa_with_guardian_set(&env, 0);
+        let mut sigs = Vec::new(&env);
+        sigs.push_back(Signature {
+            guardian_index: 1,
+            r: BytesN::<32>::from_array(&env, &[0u8; 32]),
+            s: BytesN::<32>::from_array(&env, &[0u8; 32]),
+            v: 0,
+        });
+        vaa.signatures = sigs;
+
+        env.as_contract(&contract_id, || {
+            let res = verify_vaa_signatures(&vaa, &env);
+            assert_eq!(res, Err(WormholeError::GuardianIndexOutOfBounds));
+        });
+    }
+
+    #[test]
+    fn test_verify_vaa_signatures_not_ascending() {
+        let env = Env::default();
+        let base_vaa = base_vaa_with_guardian_set(&env, 0);
+        let (sig, guardian_eth) = sign_for_vaa(&env, &base_vaa, [0x77u8; 32], 1);
+        let initial_guardians = soroban_sdk::vec![&env, guardian_eth.clone(), guardian_eth];
+        let governance_emitter = BytesN::<32>::from_array(&env, &GOVERNANCE_EMITTER);
+        let contract_id = env.register(crate::Wormhole, (initial_guardians, governance_emitter));
+
+        let mut vaa = base_vaa.clone();
+        let mut sigs = Vec::new(&env);
+        sigs.push_back(sig.clone());
+        sigs.push_back(sig);
+        vaa.signatures = sigs;
+
+        env.as_contract(&contract_id, || {
+            let res = verify_vaa_signatures(&vaa, &env);
+            assert_eq!(res, Err(WormholeError::SignaturesNotAscending));
+        });
+    }
+}


### PR DESCRIPTION
Adds the Wormhole Core Soroban contract implementation. The contract verifies VAAs, supports core governance actions, posts Wormhole messages, tracks guardian sets and replay protection, and exposes query helpers used by downstream integrations.

Changes:
- Add stellar/contracts/wormhole-contract/ with initialization, VAA parsing/verification, storage, message posting, governance actions, and utility modules.
- Implement contract upgrade, guardian set upgrade, set message fee, and transfer fees governance flows.
- Add inline Rust unit tests for VAA verification, governance validation, message posting, fee handling, replay protection, and address lookup.
- Update stellar/Cargo.lock for the core contract.