### PR TITLE
tilt: wire Stellar devnet resource

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -65,6 +65,7 @@ config.define_bool("solana", False, "Enable Solana component")
 config.define_bool("solana_watcher", False, "Enable Solana watcher on guardian")
 config.define_bool("pythnet", False, "Enable PythNet component")
 config.define_bool("terra2", False, "Enable Terra 2 component")
+config.define_bool("stellar", False, "Enable Stellar component")
 config.define_bool("ci_tests", False, "Enable tests runner component")
 config.define_bool("guardiand_debug", False, "Enable dlv endpoint for guardiand")
 config.define_bool("node_metrics", False, "Enable Prometheus & Grafana for Guardian metrics")
@@ -83,6 +84,7 @@ ci = cfg.get("ci", False)
 algorand = cfg.get("algorand", ci)
 near = cfg.get("near", ci)
 aptos = cfg.get("aptos", ci)
+stellar = cfg.get("stellar", ci)
 sui = cfg.get("sui", ci)
 evm2 = cfg.get("evm2", ci)
 solana = cfg.get("solana", ci)
@@ -179,7 +181,16 @@ docker_build(
     context = ".",
     dockerfile = "node/Dockerfile",
     target = "build",
-    ignore=["./sdk/js"]
+    ignore=["./sdk/js", "./relayer"],
+
+    platform='linux/amd64',
+)
+
+k8s_yaml('stellar/stellar.yaml')
+k8s_resource(
+    'stellar',
+    port_forwards=['8000:8000'],
+    resource_deps=[]
 )
 
 def command_with_dlv(argv):
@@ -281,9 +292,17 @@ def build_node_yaml():
             if sui:
                 container["command"] += [
                     "--suiRPC",
-                    "sui:443",
+                    "http://sui:9000",
                     "--suiMoveEventType",
                     "0xf82ef05c95ebafcbeb1cce2b636448b8cd1c6daad201f7d04ecddcda15c19d52::publish_message::WormholeMessage",
+                ]
+
+            if stellar:
+                container["command"] += [
+                    "--stellarRPC",
+                    "http://stellar.default.svc.cluster.local:8000/soroban/rpc",
+                    "--stellarContract",
+                    "CBWQUIB4R65Z2DGC263FQ7BBI7TGIGOLFTYMLE6QPWBD5QDOUVJY3AKR",
                 ]
             
             # Handle evm2 configuration based on guardian count and evm2 flag
@@ -476,6 +495,8 @@ if wormchain:
     guardian_resource_deps = guardian_resource_deps + ["wormchain", "wormchain-deploy"]
 if sui:
     guardian_resource_deps = guardian_resource_deps + ["sui"]
+if stellar:
+    guardian_resource_deps = guardian_resource_deps + ["stellar"]
 
 k8s_resource(
     "guardian",


### PR DESCRIPTION
Wires the Stellar localnet resource into Tilt so developers can run Stellar alongside the guardian stack in devnet.

Changes:
- Add the stellar Tilt feature flag.
- Load stellar/stellar.yaml and expose the Stellar RPC service on port 8000.
- Pass --stellarRPC and --stellarContract to guardian when Stellar is enabled.
- Add the Stellar resource as a guardian dependency when enabled.